### PR TITLE
fix(fetch): scope fetch_timeout to build phase, not whole request

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -87,6 +87,19 @@ func (f *fetcher) rewrite(path string) string {
 	return path
 }
 
+// withFetchTimeout bounds the upstream fetch/build phase to Server.FetchTimeout.
+// It is applied only around upstream operations (Query/List/Download), never the
+// whole request: the returned readers from Download are os.File-backed handles
+// over the completed module cache, so releasing the deadline once the upstream
+// call returns is safe and keeps the deadline off the post-200 client copy.
+// A FetchTimeout of 0 disables the bound (matches the config's documented "0").
+func (f *fetcher) withFetchTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if f.cfg.Server.FetchTimeout > 0 {
+		return context.WithTimeout(ctx, f.cfg.Server.FetchTimeout)
+	}
+	return ctx, func() {}
+}
+
 func (f *fetcher) Query(ctx context.Context, path, query string) (version string, t time.Time, err error) {
 	startTime := time.Now()
 	defer func() {
@@ -95,6 +108,9 @@ func (f *fetcher) Query(ctx context.Context, path, query string) (version string
 			errorsTotal.Inc()
 		}
 	}()
+
+	ctx, cancel := f.withFetchTimeout(ctx)
+	defer cancel()
 
 	rewrittenPath := f.rewrite(path)
 	if rewrittenPath != path {
@@ -116,6 +132,9 @@ func (f *fetcher) List(ctx context.Context, path string) (versions []string, err
 			errorsTotal.Inc()
 		}
 	}()
+
+	ctx, cancel := f.withFetchTimeout(ctx)
+	defer cancel()
 
 	rewrittenPath := f.rewrite(path)
 	if rewrittenPath != path {
@@ -145,6 +164,15 @@ func (f *fetcher) Download(ctx context.Context, path, version string) (info, mod
 			errorsTotal.Inc()
 		}
 	}()
+
+	// Bound only the build phase (upstream download + in-memory zip rewrite).
+	// The returned readers are materialized over the module cache / an in-memory
+	// buffer, so cancelling once this function returns does not affect the
+	// subsequent client copy. This keeps a slow cold build from being aborted
+	// mid-stream (HTTP/2 INTERNAL_ERROR); instead it errors before headers and
+	// goproxy returns a retryable response.
+	ctx, cancel := f.withFetchTimeout(ctx)
+	defer cancel()
 
 	rewrittenPath := f.rewrite(path)
 	if rewrittenPath != path {

--- a/proxy.go
+++ b/proxy.go
@@ -61,10 +61,13 @@ func newProxy(cfg *Config, logger *slog.Logger) (*Proxy, error) {
 
 	handler := http.Handler(client)
 
-	// Add fetch timeout middleware if configured
-	if cfg.Server.FetchTimeout > 0 {
-		handler = createTimeoutMiddleware(handler, cfg.Server.FetchTimeout)
-	}
+	// NOTE: FetchTimeout is intentionally NOT applied as whole-handler middleware.
+	// A request-wide deadline also covers the post-200 client copy, so a slow
+	// cold-cache build that overran the deadline was aborted mid-stream and
+	// surfaced to the `go` client as an HTTP/2 INTERNAL_ERROR (stream reset)
+	// instead of a retryable error. The timeout is now scoped to the upstream
+	// fetch/build phase inside the fetcher (see fetcher.withFetchTimeout), which
+	// completes before any response headers are written.
 
 	server := &http.Server{
 		Addr:    cfg.Server.Address,
@@ -94,13 +97,6 @@ func newProxy(cfg *Config, logger *slog.Logger) (*Proxy, error) {
 	}, nil
 }
 
-func createTimeoutMiddleware(next http.Handler, timeout time.Duration) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), timeout)
-		defer cancel()
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestsTotal.Inc()


### PR DESCRIPTION
## Problem

`toru.zerodha.io` intermittently returned HTTP/2 `INTERNAL_ERROR` (stream resets) to the `go` client on **cold-cache** downloads of large modules (e.g. `modernc.org/libc`, `pierrec/lz4`). Once a module was cached in S3 it served reliably.

## Root cause

`fetch_timeout` was applied as **whole-handler middleware** (`createTimeoutMiddleware` → `context.WithTimeout(r.Context(), …)`), so the single deadline covered the upstream build **and** the post-`200` client copy. On a cold cache, a large-module build (`go mod download` + optional zip rewrite) under limited CPU could overrun the deadline; when it fired *after* headers were already written, the handler returned and the HTTP/2 server sent `RST_STREAM` → the client saw `INTERNAL_ERROR`. There was no path to emit a retryable 5xx once headers were out.

## Fix

- Remove the whole-handler timeout middleware (`proxy.go`).
- Scope the timeout to the **upstream fetch/build phase only**, inside the fetcher (`Query` / `List` / `Download`) via a new `withFetchTimeout` helper.
- `Download`'s returned readers are materialized over the module cache, so releasing the deadline once the upstream call returns keeps it off the client copy. An overrun now fails **before** response headers are written, so goproxy returns a retryable response instead of resetting the stream.

`FetchTimeout = 0` still disables the bound (matches the documented config behavior).

## Testing

- `go build ./...`, `go vet ./...`, and the full test suite pass. The existing `Download` tests passing confirms the returned readers are not tied to the (now-released) build context.

## Rollout context

Paired with infra changes (ladder so toru fails first): toru `fetch_timeout` 85s < HAProxy 95s < CF ~100s < ALB 105s. This image will be tagged `v0.2.6-rc.1`.