### PR TITLE
Draft: Add pnpm/npm proxy support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,104 @@
 
 # toru
 
-_Toru is a Go module proxy with caching and rewrite capabilities, built on top of the [goproxy/goproxy](https://github.com/goproxy/goproxy) library._
-
-Toru extends the functionality by adding features such as caching (S3) and configurable rewrite rules for module paths.
+_Toru is a multi-protocol dependency proxy. It started as a Go module proxy on top of [goproxy/goproxy](https://github.com/goproxy/goproxy) and now also supports npm registry read/install flows compatible with pnpm._
 
 ## Features
 
-- Proxies Go module requests
-- Supports caching (S3 and disk)
-- Avoids persistently caching mutable module metadata like `/@v/list` and `@latest` by default
-- Configurable rewrite rules for module paths
-- Prometheus-compatible metrics endpoint
+- Go module proxy protocol support
+- npm registry read/install support for npm and pnpm
+- Single process, single config, multi-listener runtime
+- Disk and S3-backed caching for Go artifacts
+- Disk-backed npm metadata caching and conditional tarball caching when `cache.enabled = true`, `cache.type = "disk"`, and `cache.disk.path` is set
+- Go vanity import path rewrites
+- npm tarball URL rewriting back to Toru
+- Protocol-aware auth hooks for protected Go paths and npm scopes
+- Prometheus-compatible metrics endpoint on every listener
+
+## Current scope
+
+Implemented today:
+- Go proxying with existing rewrite and cache behavior
+- npm package metadata requests
+- npm tarball requests
+- scoped and unscoped npm packages
+- npm metadata TTL cache on disk
+- protected npm scopes via auth modules
+
+Not implemented yet:
+- npm publish APIs
+- host-based multi-protocol dispatch on a single listener
+
+For now, if you want both protocols in one process, run separate listeners, one protocol per listener.
 
 ## Running with Docker
 
-You can use the following command to run Toru using Docker:
-
 ```bash
-docker run --rm -p 8888:8888 ghcr.io/mr-karan/toru:latest
+docker run --rm -p 8888:8888 -p 8889:8889 ghcr.io/mr-karan/toru:latest
 ```
 
-## Rewrite Rules
+## Configuration
 
-Toru supports rewrite rules that allow you to map vanity import paths to their actual repository locations. This feature is particularly useful for organizations that want to use custom import paths for their Go packages.
+Toru is configured via TOML. See [config.sample.toml](./config.sample.toml) for a complete example.
 
-### Example
+### Legacy Go-only mode
 
-Consider the following rewrite rule in your `config.toml`:
+If you omit `[[listeners]]` and `protocols.*`, Toru preserves the legacy Go-only behavior and serves the Go proxy on `server.address`.
+
+```toml
+[server]
+address = ":8888"
+log_level = "info"
+fetch_timeout = "30s"
+
+[cache]
+enabled = true
+type = "disk"
+
+[cache.disk]
+path = "/tmp/toru-cache"
+```
+
+### Multi-listener mode
+
+```toml
+[server]
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":8888"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":8889"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+
+[cache.disk]
+path = "/tmp/toru-cache"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:8889"
+```
+
+## Go mode
+
+### Rewrite rules
+
+Toru supports rewrite rules that map vanity import paths to their actual repository locations.
 
 ```toml
 [[rewrite_rules]]
@@ -36,108 +107,203 @@ vanity_path = "go.example.com"
 target_path = "gitlab.example.com"
 ```
 
-With this rule in place:
-
-1. When a user tries to fetch a package with the import path `go.example.com/awesome-pkg`, Toru intercepts this request.
-2. Instead of looking for the package at `go.example.com/awesome-pkg`, Toru rewrites the request to `gitlab.example.com/awesome-pkg`.
-3. Toru then fetches the package from the actual repository location at `gitlab.example.com/awesome-pkg`.
-
-### Why is this useful?
-
-1. **Vanity URLs**: You can use a clean, memorable vanity URL for your packages, making it easier for user to import them.
-2. **Repository abstraction**: You can change the underlying repository location without affecting the import paths used by your user.
-3. **Private repositories**: You can use rewrite rules to map public vanity URLs to private repository locations, allowing you to control access to your internal packages.
-
-## Configuration
-
-Toru can be configured using a TOML file and environment variables. Refer to [config.sample.toml](./config.sample.toml) for reference.
+With this rule:
+1. clients request `go.example.com/awesome-pkg`
+2. Toru rewrites to `gitlab.example.com/awesome-pkg`
+3. Toru fetches from the actual repository location
 
 ### Mutable metadata caching
 
 Toru treats `/@v/list`, `@latest`, and non-canonical `.info` lookups as mutable metadata.
-
-By default, persistent caching for that metadata is disabled in the sample config:
 
 ```toml
 [cache]
 mutable_metadata_ttl = "0s"
 ```
 
-Set `cache.mutable_metadata_ttl` to a non-zero duration if you want short-lived persistent caching for mutable metadata while still caching immutable `.mod` and `.zip` artifacts normally.
+Set `cache.mutable_metadata_ttl` to a non-zero duration if you want short-lived persistent caching for mutable Go metadata while still caching immutable `.mod` and `.zip` artifacts normally.
 
-## Local Dev
+### Go auth
 
-To build and run the project locally, use the provided `justfile`:
+Go auth continues to work through auth modules configured under `[auth]`.
 
-```bash
-just build
-just run
-```
-
-This will build the binary and run it with the default configuration file (`config.toml`).
-
-## Metrics
-
-Toru exposes Prometheus-compatible metrics at the `/metrics` endpoint. Available metrics include:
-
-```
-toru_requests_total: Total number of requests
-toru_request_duration_seconds: Request duration
-toru_upstream_fetch_duration_seconds: Upstream fetch duration
-toru_response_size_bytes: Response size
-toru_rewrite_rules_applied_total: Number of times rewrite rules were applied
-toru_errors_total: Total number of errors encountered
-toru_cache_hits_total: Total cache hits
-toru_cache_misses_total: Total cache misses
-toru_cache_writes_total: Total cache writes
-toru_cache_errors_total: Total cache errors
-```
-
-
-## Authentication for Private Repositories
-
-### For the Proxy
-
-#### Using .netrc
-
-Create or edit the `.netrc` file in your home directory:
-
-```
-machine gitlab.example.com
-login your-username
-password your-access-token
-```
-
-#### Using Git Configuration
-
-Add this to your `.gitconfig`
-
-```
-[url "ssh://git@gitlab.example.com"]
-	insteadOf = https://gitlab.example.com
-```
-
-### Client-side Authentication
-
-Toru provides support for client-side authentication through authentication modules.
-
-To enable authentication, you can specify the modules in your configuration file:
+Example:
 
 ```toml
-[auth.modules]
+[auth]
+enabled = true
+
+[[auth.modules]]
 name = "gitlab"
 type = "gitlab_access_token"
 options.root_url = "https://gitlab.example.com"
 options.protected_uri = "go.example.com"
 ```
 
-#### GitLab Access Token
-
-By providing the GitLab access token in the basic auth, clients can authenticate 
-with the GitLab API to check if the user has access to the repository.
-
-To authenticate using the access token, use the following command:
+Client example:
 
 ```bash
 export GOPROXY=https://gitlab:<access_token>@toru.example.com:9443
+```
+
+## npm / pnpm mode
+
+### Registry behavior
+
+Toru serves npm metadata, rewrites every `dist.tarball` URL back to Toru, fetches tarballs from upstream, and uses disk-backed tarball caching only when all of these are true:
+- `cache.enabled = true`
+- `cache.type = "disk"`
+- `cache.disk.path` is set
+
+### npm metadata cache
+
+npm metadata uses a TTL cache on disk.
+
+```toml
+[protocols.npm]
+metadata_ttl = "5m"
+```
+
+The npm metadata cache is only active when all of these are true:
+- `cache.enabled = true`
+- `cache.type = "disk"`
+- `cache.disk.path` is set
+- `protocols.npm.metadata_ttl > 0`
+
+If any of those are false, npm metadata is always fetched fresh from upstream.
+
+### npm protected scopes
+
+You can require auth for specific npm scopes.
+
+```toml
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:8889"
+
+[[protocols.npm.protected_scopes]]
+scope = "@toru"
+auth_module = "static"
+```
+
+Accepted auth forms for protected npm scopes:
+- Basic auth, where username is the auth module name and password is the token
+- `Authorization: Bearer <token>`
+
+### Client usage
+
+pnpm:
+
+```bash
+pnpm config set registry http://127.0.0.1:8889
+pnpm add is-number
+```
+
+npm:
+
+```bash
+npm config set registry http://127.0.0.1:8889
+npm install is-number
+```
+
+Protected-scope example with bearer token in `.npmrc`:
+
+```ini
+registry=http://127.0.0.1:8889/
+//127.0.0.1:8889/:_authToken=secret
+always-auth=true
+```
+
+## Front-proxy routing examples
+
+Current deployment model is one Toru process with separate listeners per protocol.
+
+HAProxy port split example:
+
+```haproxy
+frontend deps
+    bind *:443 ssl crt /etc/ssl/example.pem
+    use_backend toru_go if { hdr(host) -i go.example.com }
+    use_backend toru_npm if { hdr(host) -i npm.example.com }
+
+backend toru_go
+    server toru-go 127.0.0.1:8888
+
+backend toru_npm
+    server toru-npm 127.0.0.1:8889
+```
+
+Toru itself does not yet dispatch Go and npm traffic by host on a single listener. Keep one protocol per listener and let the front proxy route by host or port.
+
+## Local development
+
+Build and run:
+
+```bash
+just build
+just run
+```
+
+Or use the config file directly:
+
+```bash
+go run . --config config.sample.toml
+```
+
+## Real-client smoke commands
+
+Go:
+
+```bash
+GOPROXY=http://127.0.0.1:8888 go mod download rsc.io/quote@v1.5.2
+```
+
+pnpm:
+
+```bash
+pnpm config set registry http://127.0.0.1:8889
+pnpm add is-number
+```
+
+## Metrics
+
+Toru exposes Prometheus-compatible metrics at `/metrics`.
+
+Current metric set includes the legacy aggregate counters plus protocol-aware additions.
+
+Legacy metrics retained for compatibility:
+
+```
+toru_requests_total
+toru_request_duration_seconds
+toru_upstream_fetch_duration_seconds
+toru_response_size_bytes
+toru_rewrite_rules_applied_total
+toru_errors_total
+toru_cache_hits_total
+toru_cache_misses_total
+toru_cache_writes_total
+toru_cache_errors_total
+```
+
+New protocol-aware metrics include:
+
+```
+toru_requests_by_protocol_total{protocol,kind}
+toru_request_duration_by_protocol_seconds{protocol,kind}
+toru_response_size_by_protocol_bytes{protocol,kind}
+toru_cache_hits_by_protocol_total{protocol,class}
+toru_cache_misses_by_protocol_total{protocol,class}
+toru_cache_writes_by_protocol_total{protocol,class}
+toru_cache_errors_by_protocol_total{protocol,class}
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ fetch_timeout = "30s"
 enabled = true
 upstream = "https://registry.npmjs.org"
 metadata_ttl = "5m"
-base_url = "http://127.0.0.1:8889"
+base_url = "http://127.0.0.1:8889" # required; used for tarball URL rewrites
 ```
 
 ### Single-listener host-dispatch mode
@@ -122,7 +122,7 @@ fetch_timeout = "30s"
 enabled = true
 upstream = "https://registry.npmjs.org"
 metadata_ttl = "5m"
-base_url = "https://npm.example.com"
+base_url = "https://npm.example.com" # required; must match the npm-facing origin
 ```
 
 Rules for shared listeners:
@@ -193,7 +193,7 @@ Toru serves npm metadata, rewrites every `dist.tarball` URL back to Toru, fetche
 
 ### npm metadata cache
 
-npm metadata uses a TTL cache on disk. When a cached entry goes stale and the upstream registry returned an `ETag`, Toru revalidates it with `If-None-Match` before replacing the cached body.
+npm metadata uses a TTL cache on disk. When a cached entry goes stale and the upstream registry returned an `ETag`, Toru revalidates it with `If-None-Match` and extends freshness deterministically on `304 Not Modified`.
 
 ```toml
 [protocols.npm]
@@ -211,6 +211,8 @@ If any of those are false, npm metadata is always fetched fresh from upstream.
 ### npm protected scopes
 
 You can require auth for specific npm scopes.
+
+`protocols.npm.base_url` is required whenever npm mode is enabled because metadata tarball URLs are rewritten back to Toru.
 
 ```toml
 [auth]
@@ -235,6 +237,11 @@ auth_module = "static"
 Accepted auth forms for protected npm scopes:
 - Basic auth, where username is the auth module name and password is the token
 - `Authorization: Bearer <token>`
+
+For `gitlab_access_token` modules protecting npm scopes:
+- `options.root_url` is required
+- `options.project_prefix` is optional and maps `@scope/pkg` to `<project_prefix>/pkg`
+- `options.protected_uri` is still used for Go auth, but npm scope protection is driven by `[[protocols.npm.protected_scopes]]`
 
 ### Client usage
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ Implemented today:
 - scoped and unscoped npm packages
 - npm metadata TTL cache on disk
 - protected npm scopes via auth modules
+- GitLab-backed npm rewrite rules for npm-valid scopes such as `@example-commons/foo`
 
 Not implemented yet:
 - npm publish APIs
+- raw `git+https://...` dependency interception
+- monorepo subdir packaging for rewrite-backed packages
+- arbitrary build steps during rewrite-backed packaging
 
 ## Running with Docker
 
@@ -208,6 +212,32 @@ The npm metadata cache is only active when all of these are true:
 
 If any of those are false, npm metadata is always fetched fresh from upstream.
 
+### npm rewrite rules backed by GitLab repos
+
+Toru can also synthesize npm packages directly from GitLab repos without a publish step.
+This is the npm analogue of Go rewrite rules, but it uses npm-valid scope names.
+
+Example:
+
+```toml
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = "gitlab.example.com"
+target_group = "commons"
+auth_module = "gitlab"
+```
+
+With that rule:
+- `@example-commons/foo` maps to `gitlab.example.com/commons/foo`
+- Git tags such as `v1.2.3` or `1.2.3` become installable npm versions
+- Toru synthesizes metadata and tarballs and serves them through the normal npm registry endpoints
+
+v1 limits for rewrite-backed packages:
+- root-level `package.json` is required
+- `package.json.name` must exactly match the public rewritten package name
+- repo contents are packaged as-is; Toru does not run builds
+- raw git dependencies like `git+https://...` are not intercepted by Toru
+
 ### npm protected scopes
 
 You can require auth for specific npm scopes.
@@ -243,6 +273,11 @@ For `gitlab_access_token` modules protecting npm scopes:
 - `options.project_prefix` is optional and maps `@scope/pkg` to `<project_prefix>/pkg`
 - `options.protected_uri` is still used for Go auth, but npm scope protection is driven by `[[protocols.npm.protected_scopes]]`
 
+For `gitlab_access_token` modules used by npm rewrite rules:
+- rewrite access is authorized against the derived GitLab repo path from the rewrite rule
+- `options.project_prefix` is ignored when a derived `RepoPath` is present
+- this preserves the Go-like model where the GitLab token is the source of truth for repo access
+
 ### Client usage
 
 pnpm:
@@ -250,6 +285,18 @@ pnpm:
 ```bash
 pnpm config set registry http://127.0.0.1:8889
 pnpm add is-number
+```
+
+Rewrite-backed package example:
+
+```ini
+registry=https://npm.example.com
+//npm.example.com/:_authToken=<token>
+always-auth=true
+```
+
+```bash
+pnpm add @example-commons/foo
 ```
 
 npm:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Toru serves npm metadata, rewrites every `dist.tarball` URL back to Toru, fetche
 
 ### npm metadata cache
 
-npm metadata uses a TTL cache on disk.
+npm metadata uses a TTL cache on disk. When a cached entry goes stale and the upstream registry returned an `ETag`, Toru revalidates it with `If-None-Match` before replacing the cached body.
 
 ```toml
 [protocols.npm]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _Toru is a multi-protocol dependency proxy. It started as a Go module proxy on t
 - npm registry read/install support for npm and pnpm
 - Single process, single config, multi-listener runtime
 - Disk and S3-backed caching for Go artifacts
-- Disk-backed npm metadata caching and conditional tarball caching when `cache.enabled = true`, `cache.type = "disk"`, and `cache.disk.path` is set
+- npm metadata and tarball caching for disk or S3 cache backends when caching is enabled and configured
 - Go vanity import path rewrites
 - npm tarball URL rewriting back to Toru
 - Protocol-aware auth hooks for protected Go paths and npm scopes
@@ -23,7 +23,7 @@ Implemented today:
 - npm package metadata requests
 - npm tarball requests
 - scoped and unscoped npm packages
-- npm metadata TTL cache on disk
+- npm metadata TTL cache on disk or S3
 - protected npm scopes via auth modules
 - GitLab-backed npm rewrite rules for npm-valid scopes such as `@example-commons/foo`
 
@@ -190,14 +190,14 @@ export GOPROXY=https://gitlab:<access_token>@toru.example.com:9443
 
 ### Registry behavior
 
-Toru serves npm metadata, rewrites every `dist.tarball` URL back to Toru, fetches tarballs from upstream, and uses disk-backed tarball caching only when all of these are true:
+Toru serves npm metadata, rewrites every `dist.tarball` URL back to Toru, fetches tarballs from upstream, and caches tarballs when all of these are true:
 - `cache.enabled = true`
-- `cache.type = "disk"`
-- `cache.disk.path` is set
+- `cache.type = "disk"` with `cache.disk.path` set, or
+- `cache.type = "s3"` with `cache.s3` configured
 
 ### npm metadata cache
 
-npm metadata uses a TTL cache on disk. When a cached entry goes stale and the upstream registry returned an `ETag`, Toru revalidates it with `If-None-Match` and extends freshness deterministically on `304 Not Modified`.
+npm metadata uses a TTL cache on the configured disk or S3 cache backend. When a cached entry goes stale and the upstream registry returned an `ETag`, Toru revalidates it with `If-None-Match` and extends freshness deterministically on `304 Not Modified`.
 
 ```toml
 [protocols.npm]
@@ -206,8 +206,7 @@ metadata_ttl = "5m"
 
 The npm metadata cache is only active when all of these are true:
 - `cache.enabled = true`
-- `cache.type = "disk"`
-- `cache.disk.path` is set
+- either `cache.type = "disk"` with `cache.disk.path` set, or `cache.type = "s3"` with `cache.s3` configured
 - `protocols.npm.metadata_ttl > 0`
 
 If any of those are false, npm metadata is always fetched fresh from upstream.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ Implemented today:
 
 Not implemented yet:
 - npm publish APIs
-- host-based multi-protocol dispatch on a single listener
-
-For now, if you want both protocols in one process, run separate listeners, one protocol per listener.
 
 ## Running with Docker
 
@@ -94,6 +91,45 @@ upstream = "https://registry.npmjs.org"
 metadata_ttl = "5m"
 base_url = "http://127.0.0.1:8889"
 ```
+
+### Single-listener host-dispatch mode
+
+You can also bind one listener and route by `Host` header when protocols and hosts are aligned by index.
+
+```toml
+[server]
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "shared"
+address = ":443"
+protocols = ["go", "npm"]
+hosts = ["go.example.com", "npm.example.com"]
+
+[cache]
+enabled = true
+type = "disk"
+
+[cache.disk]
+path = "/tmp/toru-cache"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+base_url = "https://npm.example.com"
+```
+
+Rules for shared listeners:
+- `listeners.protocols` and `listeners.hosts` must have the same length
+- each host maps to the protocol at the same index
+- duplicate protocols or duplicate hosts are rejected
+- unknown hosts on a shared listener return `421 Misdirected Request`
 
 ## Go mode
 
@@ -226,9 +262,11 @@ always-auth=true
 
 ## Front-proxy routing examples
 
-Current deployment model is one Toru process with separate listeners per protocol.
+Current deployment model is one Toru process that can either:
+- run separate listeners per protocol, or
+- run one shared listener and dispatch by `Host` header
 
-HAProxy port split example:
+HAProxy host split example:
 
 ```haproxy
 frontend deps
@@ -243,7 +281,7 @@ backend toru_npm
     server toru-npm 127.0.0.1:8889
 ```
 
-Toru itself does not yet dispatch Go and npm traffic by host on a single listener. Keep one protocol per listener and let the front proxy route by host or port.
+If you prefer not to use shared-listener host dispatch inside Toru, you can still keep one protocol per listener and let the front proxy route by host or port.
 
 ## Local development
 

--- a/auth.go
+++ b/auth.go
@@ -10,30 +10,50 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
-// Authentiactor interface defines the methods to authenticate the user.
+// AuthRequest carries protocol-aware authorization context.
+type AuthRequest struct {
+	Protocol string
+	Path     string
+	Resource string
+}
+
+// Authenticator defines protocol-aware authentication.
 type Authenticator interface {
-	Authenticate(token, projectPath string) (bool, bool, error)
+	Authenticate(token string, req AuthRequest) (bool, bool, error)
 }
 
 var (
 	_               = Authenticator(&GitLabAuthenticator{})
+	_               = Authenticator(&StaticTokenAuthenticator{})
 	ErrorAuthFailed = errors.New("authentication failed")
 )
 
-// GitLabAuthenticator is a struct that implements the Authenticator interface.
+// GitLabAuthenticator checks whether a token can access a GitLab project path.
 type GitLabAuthenticator struct {
 	RootURL      string
 	ProtectedURI string
+	ProjectPrefix string
 }
 
-// Authenticate method authenticates the user based on the token and project path.
-func (g *GitLabAuthenticator) Authenticate(token, uri string) (bool, bool, error) {
-	projectCandidates, skip, err := extractProjectCandidates(uri, g.ProtectedURI)
+func (g *GitLabAuthenticator) Authenticate(token string, req AuthRequest) (bool, bool, error) {
+	var (
+		projectCandidates []string
+		skip              bool
+		err               error
+	)
+
+	switch req.Protocol {
+	case "go":
+		projectCandidates, skip, err = extractProjectCandidates(req.Path, g.ProtectedURI)
+	case "npm":
+		projectCandidates, skip, err = extractNPMProjectCandidates(req.Resource, g.ProtectedURI, g.ProjectPrefix)
+	default:
+		return true, false, nil
+	}
 	if err != nil || skip {
 		return skip, false, err
 	}
 
-	// Create a new GitLab client with the user's token
 	gl, err := gitlab.NewClient(token, gitlab.WithBaseURL(g.RootURL))
 	if err != nil {
 		return skip, false, fmt.Errorf("failed to create GitLab client: %w", err)
@@ -51,10 +71,8 @@ func (g *GitLabAuthenticator) Authenticate(token, uri string) (bool, bool, error
 			if strings.Contains(err.Error(), "401 Unauthorized") || strings.Contains(err.Error(), "403 Forbidden") {
 				return skip, false, ErrorAuthFailed
 			}
-
 			return skip, false, fmt.Errorf("failed to get project: %w", err)
 		}
-
 		if prj != nil {
 			return skip, true, nil
 		}
@@ -93,28 +111,68 @@ func extractProjectCandidates(uri, protectedURI string) ([]string, bool, error) 
 	return slices.Compact(projectCandidates), false, nil
 }
 
-// NewGitlabAuthenticator creates a new GitLab authenticator.
+func extractNPMProjectCandidates(pkg, protectedScope, projectPrefix string) ([]string, bool, error) {
+	protectedScope = strings.TrimSpace(protectedScope)
+	if protectedScope == "" {
+		return nil, false, fmt.Errorf("protected_uri is empty")
+	}
+	if pkg != protectedScope && !strings.HasPrefix(pkg, protectedScope+"/") {
+		return nil, true, nil
+	}
+	name := strings.TrimPrefix(pkg, protectedScope)
+	name = strings.TrimPrefix(name, "/")
+	if name == "" || strings.Contains(name, "/") {
+		return nil, false, fmt.Errorf("invalid npm package path")
+	}
+	candidate := name
+	if projectPrefix != "" {
+		candidate = strings.TrimSuffix(projectPrefix, "/") + "/" + name
+	}
+	return []string{candidate}, false, nil
+}
+
+// StaticTokenAuthenticator allows deterministic auth testing and simple deployments.
+type StaticTokenAuthenticator struct {
+	Token string
+}
+
+func (s *StaticTokenAuthenticator) Authenticate(token string, req AuthRequest) (bool, bool, error) {
+	if s.Token == "" {
+		return false, false, fmt.Errorf("missing token")
+	}
+	if token != s.Token {
+		return false, false, ErrorAuthFailed
+	}
+	return false, true, nil
+}
+
 func NewGitlabAuthenticator(opts map[string]interface{}) (*GitLabAuthenticator, error) {
-	// Check if the URL is provided.
 	url, ok := opts["root_url"].(string)
 	if !ok {
 		return nil, fmt.Errorf("missing root_url")
 	}
-
-	// Check if the protected URI is provided.
-	protectedURIs, ok := opts["protected_uri"].(string)
+	protectedURI, ok := opts["protected_uri"].(string)
 	if !ok {
 		return nil, fmt.Errorf("missing protected_uri")
 	}
-
-	return &GitLabAuthenticator{RootURL: url, ProtectedURI: protectedURIs}, nil
+	projectPrefix, _ := opts["project_prefix"].(string)
+	return &GitLabAuthenticator{RootURL: url, ProtectedURI: protectedURI, ProjectPrefix: projectPrefix}, nil
 }
 
-// NewAuthenticator creates a new authenticator based on the module type.
+func NewStaticTokenAuthenticator(opts map[string]interface{}) (*StaticTokenAuthenticator, error) {
+	token, ok := opts["token"].(string)
+	if !ok || token == "" {
+		return nil, fmt.Errorf("missing token")
+	}
+	return &StaticTokenAuthenticator{Token: token}, nil
+}
+
 func NewAuthenticator(module AuthModule) (Authenticator, error) {
 	switch module.Type {
 	case "gitlab_access_token":
 		return NewGitlabAuthenticator(module.Options)
+	case "static_token":
+		return NewStaticTokenAuthenticator(module.Options)
 	default:
 		return nil, fmt.Errorf("unsupported auth type: %s", module.Type)
 	}

--- a/auth.go
+++ b/auth.go
@@ -16,6 +16,7 @@ type AuthRequest struct {
 	Path     string
 	Resource string
 	Scope    string
+	RepoPath string
 }
 
 // Authenticator defines protocol-aware authentication.
@@ -47,11 +48,15 @@ func (g *GitLabAuthenticator) Authenticate(token string, req AuthRequest) (bool,
 	case "go":
 		projectCandidates, skip, err = extractProjectCandidates(req.Path, g.ProtectedURI)
 	case "npm":
-		protectedScope := req.Scope
-		if protectedScope == "" {
-			protectedScope = g.ProtectedURI
+		if req.RepoPath != "" {
+			projectCandidates, skip, err = extractExplicitRepoPathCandidate(req.RepoPath)
+		} else {
+			protectedScope := req.Scope
+			if protectedScope == "" {
+				protectedScope = g.ProtectedURI
+			}
+			projectCandidates, skip, err = extractNPMProjectCandidates(req.Resource, protectedScope, g.ProjectPrefix)
 		}
-		projectCandidates, skip, err = extractNPMProjectCandidates(req.Resource, protectedScope, g.ProjectPrefix)
 	default:
 		return true, false, nil
 	}
@@ -114,6 +119,23 @@ func extractProjectCandidates(uri, protectedURI string) ([]string, bool, error) 
 	}
 
 	return slices.Compact(projectCandidates), false, nil
+}
+
+func extractExplicitRepoPathCandidate(repoPath string) ([]string, bool, error) {
+	repoPath = strings.Trim(strings.TrimSpace(repoPath), "/")
+	if repoPath == "" {
+		return nil, false, fmt.Errorf("repo path is empty")
+	}
+	parts := strings.Split(repoPath, "/")
+	if len(parts) < 2 {
+		return nil, false, fmt.Errorf("invalid repo path")
+	}
+	for _, part := range parts {
+		if part == "" {
+			return nil, false, fmt.Errorf("invalid repo path")
+		}
+	}
+	return []string{repoPath}, false, nil
 }
 
 func extractNPMProjectCandidates(pkg, protectedScope, projectPrefix string) ([]string, bool, error) {

--- a/auth.go
+++ b/auth.go
@@ -15,6 +15,7 @@ type AuthRequest struct {
 	Protocol string
 	Path     string
 	Resource string
+	Scope    string
 }
 
 // Authenticator defines protocol-aware authentication.
@@ -30,8 +31,8 @@ var (
 
 // GitLabAuthenticator checks whether a token can access a GitLab project path.
 type GitLabAuthenticator struct {
-	RootURL      string
-	ProtectedURI string
+	RootURL       string
+	ProtectedURI  string
 	ProjectPrefix string
 }
 
@@ -46,7 +47,11 @@ func (g *GitLabAuthenticator) Authenticate(token string, req AuthRequest) (bool,
 	case "go":
 		projectCandidates, skip, err = extractProjectCandidates(req.Path, g.ProtectedURI)
 	case "npm":
-		projectCandidates, skip, err = extractNPMProjectCandidates(req.Resource, g.ProtectedURI, g.ProjectPrefix)
+		protectedScope := req.Scope
+		if protectedScope == "" {
+			protectedScope = g.ProtectedURI
+		}
+		projectCandidates, skip, err = extractNPMProjectCandidates(req.Resource, protectedScope, g.ProjectPrefix)
 	default:
 		return true, false, nil
 	}
@@ -151,10 +156,7 @@ func NewGitlabAuthenticator(opts map[string]interface{}) (*GitLabAuthenticator, 
 	if !ok {
 		return nil, fmt.Errorf("missing root_url")
 	}
-	protectedURI, ok := opts["protected_uri"].(string)
-	if !ok {
-		return nil, fmt.Errorf("missing protected_uri")
-	}
+	protectedURI, _ := opts["protected_uri"].(string)
 	projectPrefix, _ := opts["project_prefix"].(string)
 	return &GitLabAuthenticator{RootURL: url, ProtectedURI: protectedURI, ProjectPrefix: projectPrefix}, nil
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -130,3 +130,20 @@ func TestStaticTokenAuthenticator(t *testing.T) {
 		t.Fatalf("correct token must pass auth, got skip=%v ok=%v err=%v", skip, ok, err)
 	}
 }
+
+func TestNewGitlabAuthenticatorAllowsNPMOnlyConfig(t *testing.T) {
+	t.Parallel()
+	a, err := NewGitlabAuthenticator(map[string]interface{}{
+		"root_url":       "https://gitlab.example.com",
+		"project_prefix": "team/npm",
+	})
+	if err != nil {
+		t.Fatalf("NewGitlabAuthenticator() error = %v", err)
+	}
+	if a.ProtectedURI != "" {
+		t.Fatalf("ProtectedURI = %q, want empty", a.ProtectedURI)
+	}
+	if a.ProjectPrefix != "team/npm" {
+		t.Fatalf("ProjectPrefix = %q, want %q", a.ProjectPrefix, "team/npm")
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -131,6 +131,20 @@ func TestStaticTokenAuthenticator(t *testing.T) {
 	}
 }
 
+func TestExtractExplicitRepoPathCandidate(t *testing.T) {
+	t.Parallel()
+	candidates, skip, err := extractExplicitRepoPathCandidate("platform/commons/foo")
+	if err != nil {
+		t.Fatalf("extractExplicitRepoPathCandidate() error = %v", err)
+	}
+	if skip {
+		t.Fatalf("extractExplicitRepoPathCandidate() skip = true, want false")
+	}
+	if len(candidates) != 1 || candidates[0] != "platform/commons/foo" {
+		t.Fatalf("extractExplicitRepoPathCandidate() = %v, want [platform/commons/foo]", candidates)
+	}
+}
+
 func TestNewGitlabAuthenticatorAllowsNPMOnlyConfig(t *testing.T) {
 	t.Parallel()
 	a, err := NewGitlabAuthenticator(map[string]interface{}{

--- a/auth_test.go
+++ b/auth_test.go
@@ -69,3 +69,64 @@ func TestExtractProjectCandidates(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractNPMProjectCandidates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		pkg            string
+		protectedScope string
+		projectPrefix  string
+		want           []string
+		wantSkip       bool
+		wantErr        bool
+	}{
+		{
+			name:           "scoped package with prefix",
+			pkg:            "@toru/fixture-scoped",
+			protectedScope: "@toru",
+			projectPrefix:  "team/npm",
+			want:           []string{"team/npm/fixture-scoped"},
+		},
+		{
+			name:           "unprotected scope skipped",
+			pkg:            "@other/fixture",
+			protectedScope: "@toru",
+			wantSkip:       true,
+		},
+		{
+			name:           "invalid nested npm path",
+			pkg:            "@toru/fixture/subpath",
+			protectedScope: "@toru",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, skip, err := extractNPMProjectCandidates(tt.pkg, tt.protectedScope, tt.projectPrefix)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("extractNPMProjectCandidates() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if skip != tt.wantSkip {
+				t.Fatalf("extractNPMProjectCandidates() skip = %v, want %v", skip, tt.wantSkip)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("extractNPMProjectCandidates() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStaticTokenAuthenticator(t *testing.T) {
+	t.Parallel()
+	a := &StaticTokenAuthenticator{Token: "secret"}
+
+	if _, ok, err := a.Authenticate("wrong", AuthRequest{Protocol: "npm", Resource: "@toru/fixture"}); err != ErrorAuthFailed || ok {
+		t.Fatalf("wrong token must fail auth, got ok=%v err=%v", ok, err)
+	}
+	if skip, ok, err := a.Authenticate("secret", AuthRequest{Protocol: "npm", Resource: "@toru/fixture"}); err != nil || skip || !ok {
+		t.Fatalf("correct token must pass auth, got skip=%v ok=%v err=%v", skip, ok, err)
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -131,6 +131,14 @@ func TestStaticTokenAuthenticator(t *testing.T) {
 	}
 }
 
+func TestGitLabAuthenticatorPrefersExplicitRepoPathForNPM(t *testing.T) {
+	t.Parallel()
+	got, skip, err := extractExplicitRepoPathCandidate("platform/commons/foo")
+	if err != nil || skip || len(got) != 1 || got[0] != "platform/commons/foo" {
+		t.Fatalf("extractExplicitRepoPathCandidate() = %v skip=%v err=%v, want [platform/commons/foo] false nil", got, skip, err)
+	}
+}
+
 func TestExtractExplicitRepoPathCandidate(t *testing.T) {
 	t.Parallel()
 	candidates, skip, err := extractExplicitRepoPathCandidate("platform/commons/foo")

--- a/authz.go
+++ b/authz.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func buildAuthenticators(cfg *Config) (map[string]Authenticator, error) {
+	authenticators := make(map[string]Authenticator)
+	if !cfg.Auth.Enabled {
+		return authenticators, nil
+	}
+	for _, module := range cfg.Auth.Modules {
+		auth, err := NewAuthenticator(module)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create authenticator: %w", err)
+		}
+		authenticators[module.Name] = auth
+	}
+	return authenticators, nil
+}
+
+func authorizeRequest(w http.ResponseWriter, r *http.Request, auths map[string]Authenticator, moduleName string, req AuthRequest) bool {
+	authMethod, password, ok := r.BasicAuth()
+	if ok {
+		return authorizeToken(w, auths, authMethod, password, moduleName, req)
+	}
+
+	if req.Protocol == "npm" {
+		authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
+			token := strings.TrimSpace(parts[1])
+			if token != "" {
+				return authorizeToken(w, auths, moduleName, token, moduleName, req)
+			}
+		}
+	}
+
+	http.Error(w, "No username or password provided", http.StatusUnauthorized)
+	return false
+}
+
+func authorizeToken(w http.ResponseWriter, auths map[string]Authenticator, authMethod, password, moduleName string, req AuthRequest) bool {
+	if authMethod != moduleName {
+		http.Error(w, "Invalid auth method", http.StatusBadRequest)
+		return false
+	}
+	auth, ok := auths[authMethod]
+	if !ok {
+		http.Error(w, "Invalid auth method", http.StatusBadRequest)
+		return false
+	}
+	skip, hasAccess, err := auth.Authenticate(password, req)
+	if err != nil {
+		if err == ErrorAuthFailed {
+			http.Error(w, "Unauthorized", http.StatusForbidden)
+			return false
+		}
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return false
+	}
+	if !hasAccess && !skip {
+		http.Error(w, "Unauthorized", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+func matchProtectedScope(rules []ProtectedScopeRule, pkg string) (ProtectedScopeRule, bool) {
+	for _, rule := range rules {
+		if pkg == rule.Scope || strings.HasPrefix(pkg, rule.Scope+"/") {
+			return rule, true
+		}
+	}
+	return ProtectedScopeRule{}, false
+}

--- a/authz.go
+++ b/authz.go
@@ -22,24 +22,39 @@ func buildAuthenticators(cfg *Config) (map[string]Authenticator, error) {
 }
 
 func authorizeRequest(w http.ResponseWriter, r *http.Request, auths map[string]Authenticator, moduleName string, req AuthRequest) bool {
-	authMethod, password, ok := r.BasicAuth()
+	_, _, ok := authorizeRequestToken(r, moduleName)
 	if ok {
-		return authorizeToken(w, auths, authMethod, password, moduleName, req)
-	}
-
-	if req.Protocol == "npm" {
-		authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
-		parts := strings.SplitN(authHeader, " ", 2)
-		if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
-			token := strings.TrimSpace(parts[1])
-			if token != "" {
-				return authorizeToken(w, auths, moduleName, token, moduleName, req)
-			}
-		}
+		return authorizeRequestWithToken(w, auths, moduleName, req, r)
 	}
 
 	http.Error(w, "No username or password provided", http.StatusUnauthorized)
 	return false
+}
+
+func authorizeRequestWithToken(w http.ResponseWriter, auths map[string]Authenticator, moduleName string, req AuthRequest, r *http.Request) bool {
+	authMethod, token, ok := authorizeRequestToken(r, moduleName)
+	if !ok {
+		http.Error(w, "No username or password provided", http.StatusUnauthorized)
+		return false
+	}
+	return authorizeToken(w, auths, authMethod, token, moduleName, req)
+}
+
+func authorizeRequestToken(r *http.Request, moduleName string) (string, string, bool) {
+	authMethod, password, ok := r.BasicAuth()
+	if ok {
+		return authMethod, password, true
+	}
+	if authHeader := strings.TrimSpace(r.Header.Get("Authorization")); authHeader != "" {
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
+			token := strings.TrimSpace(parts[1])
+			if token != "" {
+				return moduleName, token, true
+			}
+		}
+	}
+	return "", "", false
 }
 
 func authorizeToken(w http.ResponseWriter, auths map[string]Authenticator, authMethod, password, moduleName string, req AuthRequest) bool {

--- a/authz.go
+++ b/authz.go
@@ -61,6 +61,10 @@ func authorizeToken(w http.ResponseWriter, auths map[string]Authenticator, authM
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return false
 	}
+	if req.Protocol == "npm" && skip {
+		http.Error(w, "Unauthorized", http.StatusForbidden)
+		return false
+	}
 	if !hasAccess && !skip {
 		http.Error(w, "Unauthorized", http.StatusForbidden)
 		return false

--- a/authz_test.go
+++ b/authz_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type stubAuthenticator struct {
+	skip      bool
+	hasAccess bool
+	err       error
+}
+
+func (s stubAuthenticator) Authenticate(token string, req AuthRequest) (bool, bool, error) {
+	return s.skip, s.hasAccess, s.err
+}
+
+func TestAuthorizeTokenRejectsSkippedProtectedNPMRequest(t *testing.T) {
+	rr := httptest.NewRecorder()
+	auths := map[string]Authenticator{
+		"gitlab": stubAuthenticator{skip: true, hasAccess: false},
+	}
+
+	ok := authorizeToken(rr, auths, "gitlab", "secret", "gitlab", AuthRequest{
+		Protocol: "npm",
+		Path:     "/@toru/pkg",
+		Resource: "@toru/pkg",
+	})
+	if ok {
+		t.Fatalf("authorizeToken() unexpectedly allowed skipped protected npm request")
+	}
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}
+
+func TestAuthorizeTokenAllowsSkippedUnprotectedGoRequest(t *testing.T) {
+	rr := httptest.NewRecorder()
+	auths := map[string]Authenticator{
+		"gitlab": stubAuthenticator{skip: true, hasAccess: false},
+	}
+
+	ok := authorizeToken(rr, auths, "gitlab", "secret", "gitlab", AuthRequest{
+		Protocol: "go",
+		Path:     "/public.example.com/team/workflows/@v/list",
+		Resource: "/public.example.com/team/workflows/@v/list",
+	})
+	if !ok {
+		t.Fatalf("authorizeToken() unexpectedly rejected skipped unprotected go request")
+	}
+}

--- a/cache.go
+++ b/cache.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -165,7 +167,7 @@ type s3Cacher struct {
 	logger *slog.Logger
 }
 
-func newS3Cacher(cfg *Config, logger *slog.Logger) (goproxy.Cacher, error) {
+func loadAWSConfig(cfg *Config) (aws.Config, error) {
 	ctx := context.Background()
 	awsCfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(cfg.Cache.S3.Region),
@@ -176,7 +178,15 @@ func newS3Cacher(cfg *Config, logger *slog.Logger) (goproxy.Cacher, error) {
 		)),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+	return awsCfg, nil
+}
+
+func newS3Cacher(cfg *Config, logger *slog.Logger) (goproxy.Cacher, error) {
+	awsCfg, err := loadAWSConfig(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	client := s3.NewFromConfig(awsCfg)
@@ -287,6 +297,120 @@ func newDiskCacher(path string, logger *slog.Logger) goproxy.Cacher {
 	return &diskCacher{
 		cacher: goproxy.DirCacher(path),
 		logger: logger,
+	}
+}
+
+type npmCacheStore interface {
+	Get(key string) ([]byte, time.Time, error)
+	Put(key string, body []byte) error
+	Delete(key string) error
+}
+
+type diskNPMCacheStore struct {
+	root string
+}
+
+func (s *diskNPMCacheStore) path(key string) string {
+	return filepath.Join(s.root, filepath.FromSlash(key))
+}
+
+func (s *diskNPMCacheStore) Get(key string) ([]byte, time.Time, error) {
+	path := s.path(key)
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	return body, info.ModTime(), nil
+}
+
+func (s *diskNPMCacheStore) Put(key string, body []byte) error {
+	path := s.path(key)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, body, 0o644)
+}
+
+func (s *diskNPMCacheStore) Delete(key string) error {
+	path := s.path(key)
+	err := os.Remove(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+type s3NPMCacheStore struct {
+	client *s3.Client
+	bucket string
+}
+
+func (s *s3NPMCacheStore) Get(key string) ([]byte, time.Time, error) {
+	output, err := s.client.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		var nsk *types.NoSuchKey
+		if strings.Contains(err.Error(), "NoSuchKey") || errors.As(err, &nsk) {
+			return nil, time.Time{}, fs.ErrNotExist
+		}
+		return nil, time.Time{}, err
+	}
+	defer output.Body.Close()
+	body, err := io.ReadAll(output.Body)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	modTime := time.Time{}
+	if output.LastModified != nil {
+		modTime = *output.LastModified
+	}
+	return body, modTime, nil
+}
+
+func (s *s3NPMCacheStore) Put(key string, body []byte) error {
+	reader := bytes.NewReader(body)
+	_, err := s.client.PutObject(context.Background(), &s3.PutObjectInput{
+		Bucket:        aws.String(s.bucket),
+		Key:           aws.String(key),
+		Body:          reader,
+		ContentLength: aws.Int64(int64(len(body))),
+		ContentType:   aws.String("application/octet-stream"),
+	})
+	return err
+}
+
+func (s *s3NPMCacheStore) Delete(key string) error {
+	_, err := s.client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	return err
+}
+
+func newNPMCacheStore(cfg *Config) (npmCacheStore, error) {
+	if !cfg.Cache.Enabled {
+		return nil, nil
+	}
+	switch cfg.Cache.Type {
+	case "disk":
+		if cfg.Cache.Disk.Path == "" {
+			return nil, nil
+		}
+		return &diskNPMCacheStore{root: cfg.Cache.Disk.Path}, nil
+	case "s3":
+		awsCfg, err := loadAWSConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return &s3NPMCacheStore{client: s3.NewFromConfig(awsCfg), bucket: cfg.Cache.S3.Bucket}, nil
+	default:
+		return nil, nil
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -69,10 +69,17 @@ type GoProtocolConfig struct {
 }
 
 type NPMProtocolConfig struct {
-	Enabled     bool          `koanf:"enabled"`
-	Upstream    string        `koanf:"upstream"`
-	MetadataTTL time.Duration `koanf:"metadata_ttl"`
-	BaseURL     string        `koanf:"base_url"`
+	Enabled         bool                 `koanf:"enabled"`
+	Upstream        string               `koanf:"upstream"`
+	MetadataTTL     time.Duration        `koanf:"metadata_ttl"`
+	BaseURL         string               `koanf:"base_url"`
+	ProtectedScopes []ProtectedScopeRule `koanf:"protected_scopes"`
+}
+
+
+type ProtectedScopeRule struct {
+	Scope      string `koanf:"scope"`
+	AuthModule string `koanf:"auth_module"`
 }
 
 // AuthModule represents an auth module configuration.

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -158,6 +159,15 @@ func (c *Config) normalize() {
 }
 
 func (c *Config) validate() error {
+	if c.Protocols.NPM.Enabled {
+		if strings.TrimSpace(c.Protocols.NPM.BaseURL) == "" {
+			return fmt.Errorf("protocols.npm.base_url is required when npm protocol is enabled")
+		}
+		parsedBaseURL, err := url.Parse(c.Protocols.NPM.BaseURL)
+		if err != nil || parsedBaseURL.Scheme == "" || parsedBaseURL.Host == "" {
+			return fmt.Errorf("protocols.npm.base_url must be an absolute URL")
+		}
+	}
 	for _, listener := range c.Listeners {
 		if len(listener.Protocols) == 0 {
 			return fmt.Errorf("listener %q must declare at least one protocol", listener.Name)

--- a/config.go
+++ b/config.go
@@ -22,6 +22,9 @@ type Config struct {
 		FetchTimeout time.Duration `koanf:"fetch_timeout"`
 	} `koanf:"server"`
 
+	Listeners []ListenerConfig `koanf:"listeners"`
+	Protocols ProtocolsConfig  `koanf:"protocols"`
+
 	Cache struct {
 		Enabled            bool          `koanf:"enabled"`
 		Type               string        `koanf:"type"`
@@ -43,61 +46,64 @@ type Config struct {
 	} `koanf:"rewrite_rules"`
 
 	Auth struct {
-		// Enabled is a flag to enable or disable the auth module.
-		Enabled bool `koanf:"enabled"`
-
-		// Modules is a list of auth modules.
+		Enabled bool         `koanf:"enabled"`
 		Modules []AuthModule `koanf:"modules"`
 	} `koanf:"auth"`
 }
 
+type ListenerConfig struct {
+	Name      string   `koanf:"name"`
+	Address   string   `koanf:"address"`
+	Protocols []string `koanf:"protocols"`
+	Hosts     []string `koanf:"hosts"`
+}
+
+type ProtocolsConfig struct {
+	Go  GoProtocolConfig  `koanf:"go"`
+	NPM NPMProtocolConfig `koanf:"npm"`
+}
+
+type GoProtocolConfig struct {
+	Enabled      bool          `koanf:"enabled"`
+	FetchTimeout time.Duration `koanf:"fetch_timeout"`
+}
+
+type NPMProtocolConfig struct {
+	Enabled     bool          `koanf:"enabled"`
+	Upstream    string        `koanf:"upstream"`
+	MetadataTTL time.Duration `koanf:"metadata_ttl"`
+	BaseURL     string        `koanf:"base_url"`
+}
+
 // AuthModule represents an auth module configuration.
-// Auth modules are used to authenticate users.
-// The auth module implementation is determined by the Type field.
 type AuthModule struct {
-	// Name of the auth module. This is used to identify the module via
-	// the username in basic auth.
-	Name string `koanf:"name"`
-
-	// Type of the auth module. This is used to identify the module
-	// implementation.
-	Type string `koanf:"type"`
-
-	// Options is a map of options specific to the auth module. These
-	// are used to configure the auth module.
+	Name    string                 `koanf:"name"`
+	Type    string                 `koanf:"type"`
 	Options map[string]interface{} `koanf:"options"`
 }
 
-// initConfig loads config and returns a Config instance.
 func initConfig(cfgDefault, envPrefix string) (*Config, error) {
 	var (
 		ko = koanf.New(".")
 		f  = flag.NewFlagSet("app", flag.ContinueOnError)
 	)
 
-	// Configure Flags.
 	f.Usage = func() {
 		fmt.Println(f.FlagUsages())
 		os.Exit(0)
 	}
-
-	// Register flags.
 	f.String("config", cfgDefault, "Path to a config file to load.")
 
-	// Parse and Load Flags.
 	err := f.Parse(os.Args[1:])
 	if err != nil {
 		return nil, err
 	}
-
 	if err := ko.Load(posflag.Provider(f, ".", ko), nil); err != nil {
 		return nil, err
 	}
-
 	if err := ko.Load(file.Provider(ko.String("config")), toml.Parser()); err != nil {
 		return nil, err
 	}
-
 	if err := ko.Load(env.Provider(envPrefix, ".", func(s string) string {
 		return strings.Replace(strings.ToLower(strings.TrimPrefix(s, envPrefix)), "__", ".", -1)
 	}), nil); err != nil {
@@ -108,6 +114,35 @@ func initConfig(cfgDefault, envPrefix string) (*Config, error) {
 	if err := ko.Unmarshal("", cfg); err != nil {
 		return nil, err
 	}
-
+	cfg.normalize()
 	return cfg, nil
+}
+
+func (c *Config) normalize() {
+	if c.Protocols.Go.FetchTimeout == 0 {
+		c.Protocols.Go.FetchTimeout = c.Server.FetchTimeout
+	}
+	if len(c.Listeners) == 0 {
+		c.Protocols.Go.Enabled = true
+		c.Listeners = []ListenerConfig{{
+			Name:      "go",
+			Address:   c.Server.Address,
+			Protocols: []string{"go"},
+		}}
+	}
+	if !c.Protocols.Go.Enabled && !c.Protocols.NPM.Enabled {
+		for _, l := range c.Listeners {
+			for _, p := range l.Protocols {
+				switch p {
+				case "go":
+					c.Protocols.Go.Enabled = true
+				case "npm":
+					c.Protocols.NPM.Enabled = true
+				}
+			}
+		}
+	}
+	if c.Protocols.NPM.Upstream == "" {
+		c.Protocols.NPM.Upstream = "https://registry.npmjs.org"
+	}
 }

--- a/config.go
+++ b/config.go
@@ -115,6 +115,9 @@ func initConfig(cfgDefault, envPrefix string) (*Config, error) {
 		return nil, err
 	}
 	cfg.normalize()
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
 	return cfg, nil
 }
 
@@ -145,4 +148,16 @@ func (c *Config) normalize() {
 	if c.Protocols.NPM.Upstream == "" {
 		c.Protocols.NPM.Upstream = "https://registry.npmjs.org"
 	}
+}
+
+func (c *Config) validate() error {
+	for _, listener := range c.Listeners {
+		if len(listener.Protocols) == 0 {
+			return fmt.Errorf("listener %q must declare at least one protocol", listener.Name)
+		}
+		if len(listener.Protocols) > 1 {
+			return fmt.Errorf("listener %q declares multiple protocols but host dispatch is not implemented yet", listener.Name)
+		}
+	}
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -76,6 +76,7 @@ type NPMProtocolConfig struct {
 	MetadataTTL     time.Duration        `koanf:"metadata_ttl"`
 	BaseURL         string               `koanf:"base_url"`
 	ProtectedScopes []ProtectedScopeRule `koanf:"protected_scopes"`
+	RewriteRules    []NPMRewriteRule     `koanf:"rewrite_rules"`
 }
 
 type ProtectedScopeRule struct {
@@ -166,6 +167,9 @@ func (c *Config) validate() error {
 		parsedBaseURL, err := url.Parse(c.Protocols.NPM.BaseURL)
 		if err != nil || parsedBaseURL.Scheme == "" || parsedBaseURL.Host == "" {
 			return fmt.Errorf("protocols.npm.base_url must be an absolute URL")
+		}
+		if err := validateNPMRewriteRules(c.Protocols.NPM); err != nil {
+			return err
 		}
 	}
 	for _, listener := range c.Listeners {

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -75,7 +76,6 @@ type NPMProtocolConfig struct {
 	BaseURL         string               `koanf:"base_url"`
 	ProtectedScopes []ProtectedScopeRule `koanf:"protected_scopes"`
 }
-
 
 type ProtectedScopeRule struct {
 	Scope      string `koanf:"scope"`
@@ -162,9 +162,39 @@ func (c *Config) validate() error {
 		if len(listener.Protocols) == 0 {
 			return fmt.Errorf("listener %q must declare at least one protocol", listener.Name)
 		}
-		if len(listener.Protocols) > 1 {
-			return fmt.Errorf("listener %q declares multiple protocols but host dispatch is not implemented yet", listener.Name)
+		if len(listener.Protocols) == 1 {
+			continue
+		}
+		if len(listener.Hosts) != len(listener.Protocols) {
+			return fmt.Errorf("listener %q must declare one host per protocol for host dispatch", listener.Name)
+		}
+		seenProtocols := map[string]struct{}{}
+		seenHosts := map[string]struct{}{}
+		for i, protocol := range listener.Protocols {
+			if _, ok := seenProtocols[protocol]; ok {
+				return fmt.Errorf("listener %q declares duplicate protocol %q in host dispatch config", listener.Name, protocol)
+			}
+			seenProtocols[protocol] = struct{}{}
+			host := normalizeListenerHost(listener.Hosts[i])
+			if host == "" {
+				return fmt.Errorf("listener %q has empty host for protocol %q", listener.Name, protocol)
+			}
+			if _, ok := seenHosts[host]; ok {
+				return fmt.Errorf("listener %q declares duplicate host %q", listener.Name, host)
+			}
+			seenHosts[host] = struct{}{}
 		}
 	}
 	return nil
+}
+
+func normalizeListenerHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return ""
+	}
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		return parsedHost
+	}
+	return host
 }

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -51,7 +51,7 @@ fetch_timeout = "30s"
 enabled = true
 upstream = "https://registry.npmjs.org"
 metadata_ttl = "5m" # npm metadata cache is active only for disk cache + metadata_ttl > 0
-base_url = "http://127.0.0.1:8889" # for shared host-dispatch listeners, set this to the npm host origin
+base_url = "http://127.0.0.1:8889" # required; for shared host-dispatch listeners, set this to the npm host origin
 
 # Optional npm protected scope auth.
 # Requests under @toru/* require either:
@@ -68,8 +68,9 @@ enabled = false
 name = "gitlab"
 type = "gitlab_access_token"
 options.root_url = "https://gitlab.example.com"
-options.protected_uri = "go.example.com"
+options.protected_uri = "go.example.com" # used for Go auth matching
 # Optional for npm protected scopes mapped into GitLab project prefixes.
+# Npm scope protection itself is configured under [[protocols.npm.protected_scopes]].
 # options.project_prefix = "team/npm"
 
 [[auth.modules]]

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -50,7 +50,7 @@ fetch_timeout = "30s"
 [protocols.npm]
 enabled = true
 upstream = "https://registry.npmjs.org"
-metadata_ttl = "5m" # npm metadata cache is active only for disk cache + metadata_ttl > 0
+metadata_ttl = "5m" # npm metadata cache is active for configured disk or S3 cache backends when metadata_ttl > 0
 base_url = "http://127.0.0.1:8889" # required; for shared host-dispatch listeners, set this to the npm host origin
 
 # Optional GitLab-backed rewrite rules.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -53,6 +53,19 @@ upstream = "https://registry.npmjs.org"
 metadata_ttl = "5m" # npm metadata cache is active only for disk cache + metadata_ttl > 0
 base_url = "http://127.0.0.1:8889" # required; for shared host-dispatch listeners, set this to the npm host origin
 
+# Optional GitLab-backed rewrite rules.
+# Example: @example-commons/foo -> gitlab.example.com/commons/foo
+# v1 limits:
+# - root package.json required
+# - package.json.name must exactly match the public rewritten package name
+# - tags like v1.2.3 and 1.2.3 are accepted
+# - no monorepo subdir packaging or build steps
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = "gitlab.example.com"
+target_group = "commons"
+auth_module = "gitlab"
+
 # Optional npm protected scope auth.
 # Requests under @toru/* require either:
 # - Basic auth username=static password=secret, or
@@ -62,7 +75,7 @@ scope = "@toru"
 auth_module = "static"
 
 [auth]
-enabled = false
+enabled = true
 
 [[auth.modules]]
 name = "gitlab"
@@ -71,6 +84,7 @@ options.root_url = "https://gitlab.example.com"
 options.protected_uri = "go.example.com" # used for Go auth matching
 # Optional for npm protected scopes mapped into GitLab project prefixes.
 # Npm scope protection itself is configured under [[protocols.npm.protected_scopes]].
+# For npm rewrite rules, the derived repo path is used directly and project_prefix is ignored.
 # options.project_prefix = "team/npm"
 
 [[auth.modules]]

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,12 +1,32 @@
 [server]
-address = ":8888"
+address = ":8888" # legacy go-only default when [[listeners]] is omitted
 log_level = "info"
 fetch_timeout = "30s"
+
+# Legacy go-only mode example:
+# - remove all [[listeners]] blocks
+# - remove [protocols.npm]
+# - optionally remove [protocols.go] too; Toru will synthesize go-only mode from [server].address
+
+# Explicit multi-listener configuration.
+# Omit [[listeners]] to keep legacy go-only behavior on [server].address.
+# Current limitation: each listener must declare exactly one protocol.
+[[listeners]]
+name = "go"
+address = ":8888"
+protocols = ["go"]
+# hosts = ["toru.example.com"]
+
+[[listeners]]
+name = "npm"
+address = ":8889"
+protocols = ["npm"]
+# hosts = ["npm-toru.example.com"]
 
 [cache]
 enabled = true
 type = "disk"
-mutable_metadata_ttl = "0s" # 0 disables persistent cache for /@v/list, /@latest, and mutable .info queries
+mutable_metadata_ttl = "0s" # Go-only mutable metadata cache TTL
 
 [cache.disk]
 path = "/tmp/toru-cache"
@@ -17,14 +37,39 @@ path = "/tmp/toru-cache"
 # access_key = "YOUR_ACCESS_KEY"
 # secret_key = "YOUR_SECRET_KEY"
 
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m" # npm metadata cache is active only for disk cache + metadata_ttl > 0
+base_url = "http://127.0.0.1:8889"
+
+# Optional npm protected scope auth.
+# Requests under @toru/* require either:
+# - Basic auth username=static password=secret, or
+# - Authorization: Bearer secret
+[[protocols.npm.protected_scopes]]
+scope = "@toru"
+auth_module = "static"
+
 [auth]
 enabled = false
 
-[auth.modules]
+[[auth.modules]]
 name = "gitlab"
 type = "gitlab_access_token"
 options.root_url = "https://gitlab.example.com"
 options.protected_uri = "go.example.com"
+# Optional for npm protected scopes mapped into GitLab project prefixes.
+# options.project_prefix = "team/npm"
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
 
 [[rewrite_rules]]
 vanity_path = "example.com/mymodule"

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -10,7 +10,13 @@ fetch_timeout = "30s"
 
 # Explicit multi-listener configuration.
 # Omit [[listeners]] to keep legacy go-only behavior on [server].address.
-# Current limitation: each listener must declare exactly one protocol.
+# You can also configure one shared listener with protocols + hosts aligned by index,
+# for example:
+# [[listeners]]
+# name = "shared"
+# address = ":443"
+# protocols = ["go", "npm"]
+# hosts = ["go.example.com", "npm.example.com"]
 [[listeners]]
 name = "go"
 address = ":8888"
@@ -45,7 +51,7 @@ fetch_timeout = "30s"
 enabled = true
 upstream = "https://registry.npmjs.org"
 metadata_ttl = "5m" # npm metadata cache is active only for disk cache + metadata_ttl > 0
-base_url = "http://127.0.0.1:8889"
+base_url = "http://127.0.0.1:8889" # for shared host-dispatch listeners, set this to the npm host origin
 
 # Optional npm protected scope auth.
 # Requests under @toru/* require either:

--- a/config_compat_test.go
+++ b/config_compat_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// Verification contract:
+// 1. Legacy Go-only config must continue to parse.
+// 2. Legacy config must normalize into explicit Go runtime semantics.
+// 3. New multi-listener config must decode into actual listener/protocol values.
+
+func TestLegacyConfigStillParsesAsGoOnly(t *testing.T) {
+	cfgText := `[server]
+address = ":8888"
+log_level = "info"
+fetch_timeout = "30s"
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = "/tmp/toru-cache"
+
+[auth]
+enabled = false
+
+[[rewrite_rules]]
+vanity_path = "example.com/mymodule"
+target_path = "github.com/example/mymodule"
+`
+
+	cfg := loadConfigFromText(t, cfgText)
+
+	listeners := requireField(t, reflect.ValueOf(*cfg), "Listeners")
+	if listeners.Len() != 1 {
+		t.Fatalf("legacy config must synthesize exactly one Go listener, got %d", listeners.Len())
+	}
+
+	listener := listeners.Index(0)
+	address := stringField(t, listener, "Address")
+	if address != ":8888" {
+		t.Fatalf("legacy listener address = %q, want %q", address, ":8888")
+	}
+
+	protocols := stringSliceField(t, listener, "Protocols")
+	if len(protocols) != 1 || protocols[0] != "go" {
+		t.Fatalf("legacy listener protocols = %v, want [go]", protocols)
+	}
+}
+
+func TestMultiListenerConfigParses(t *testing.T) {
+	cfgText := `[server]
+address = ":9999"
+log_level = "info"
+
+[[listeners]]
+name = "go-public"
+address = ":8080"
+protocols = ["go"]
+hosts = ["toru.example.com"]
+
+[[listeners]]
+name = "npm-public"
+address = ":8081"
+protocols = ["npm"]
+hosts = ["npm-toru.example.com"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = "/tmp/toru-cache"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+base_url = "https://npm-toru.example.com"
+`
+
+	cfg := loadConfigFromText(t, cfgText)
+	root := reflect.ValueOf(*cfg)
+
+	listeners := requireField(t, root, "Listeners")
+	if listeners.Len() != 2 {
+		t.Fatalf("expected 2 listeners from config, got %d", listeners.Len())
+	}
+
+	goListener := listeners.Index(0)
+	if got := stringField(t, goListener, "Name"); got != "go-public" {
+		t.Fatalf("go listener name = %q, want %q", got, "go-public")
+	}
+	if got := stringField(t, goListener, "Address"); got != ":8080" {
+		t.Fatalf("go listener address = %q, want %q", got, ":8080")
+	}
+	if got := stringSliceField(t, goListener, "Protocols"); len(got) != 1 || got[0] != "go" {
+		t.Fatalf("go listener protocols = %v, want [go]", got)
+	}
+
+	npmListener := listeners.Index(1)
+	if got := stringField(t, npmListener, "Name"); got != "npm-public" {
+		t.Fatalf("npm listener name = %q, want %q", got, "npm-public")
+	}
+	if got := stringField(t, npmListener, "Address"); got != ":8081" {
+		t.Fatalf("npm listener address = %q, want %q", got, ":8081")
+	}
+	if got := stringSliceField(t, npmListener, "Protocols"); len(got) != 1 || got[0] != "npm" {
+		t.Fatalf("npm listener protocols = %v, want [npm]", got)
+	}
+
+	protocols := requireField(t, root, "Protocols")
+	npmProtocol := requireField(t, protocols, "NPM")
+	if !boolField(t, npmProtocol, "Enabled") {
+		t.Fatalf("protocols.npm.enabled must decode to true")
+	}
+	if got := stringField(t, npmProtocol, "Upstream"); got != "https://registry.npmjs.org" {
+		t.Fatalf("protocols.npm.upstream = %q, want npm registry upstream", got)
+	}
+	if got := stringField(t, npmProtocol, "BaseURL"); got != "https://npm-toru.example.com" {
+		t.Fatalf("protocols.npm.base_url = %q, want %q", got, "https://npm-toru.example.com")
+	}
+}
+
+func loadConfigFromText(t *testing.T, content string) *Config {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"toru", "--config", path}
+
+	cfg, err := initConfig(path, "TORU_")
+	if err != nil {
+		t.Fatalf("initConfig() error = %v", err)
+	}
+	return cfg
+}
+
+func requireField(t *testing.T, v reflect.Value, name string) reflect.Value {
+	t.Helper()
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	field := v.FieldByName(name)
+	if !field.IsValid() {
+		t.Fatalf("expected field %q to exist", name)
+	}
+	return field
+}
+
+func stringField(t *testing.T, v reflect.Value, name string) string {
+	t.Helper()
+	field := requireField(t, v, name)
+	if field.Kind() != reflect.String {
+		t.Fatalf("field %q must be string, got %s", name, field.Kind())
+	}
+	return field.String()
+}
+
+func boolField(t *testing.T, v reflect.Value, name string) bool {
+	t.Helper()
+	field := requireField(t, v, name)
+	if field.Kind() != reflect.Bool {
+		t.Fatalf("field %q must be bool, got %s", name, field.Kind())
+	}
+	return field.Bool()
+}
+
+func stringSliceField(t *testing.T, v reflect.Value, name string) []string {
+	t.Helper()
+	field := requireField(t, v, name)
+	if field.Kind() != reflect.Slice {
+		t.Fatalf("field %q must be slice, got %s", name, field.Kind())
+	}
+	out := make([]string, field.Len())
+	for i := 0; i < field.Len(); i++ {
+		if field.Index(i).Kind() != reflect.String {
+			t.Fatalf("field %q must be []string", name)
+		}
+		out[i] = field.Index(i).String()
+	}
+	return out
+}

--- a/config_compat_test.go
+++ b/config_compat_test.go
@@ -137,6 +137,48 @@ base_url = "https://npm-toru.example.com"
 	}
 }
 
+func TestNPMRewriteRulesParse(t *testing.T) {
+	cfgText := `[server]
+address = ":9999"
+log_level = "info"
+
+[[listeners]]
+name = "npm"
+address = ":8081"
+protocols = ["npm"]
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+base_url = "https://npm.example.com"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = "gitlab.example.com"
+target_group = "commons"
+auth_module = "gitlab"
+`
+
+	cfg := loadConfigFromText(t, cfgText)
+	if len(cfg.Protocols.NPM.RewriteRules) != 1 {
+		t.Fatalf("expected 1 npm rewrite rule, got %d", len(cfg.Protocols.NPM.RewriteRules))
+	}
+	rule := cfg.Protocols.NPM.RewriteRules[0]
+	if rule.Scope != "@example-commons" {
+		t.Fatalf("rewrite scope = %q, want %q", rule.Scope, "@example-commons")
+	}
+	if rule.TargetHost != "gitlab.example.com" {
+		t.Fatalf("rewrite target_host = %q, want %q", rule.TargetHost, "gitlab.example.com")
+	}
+	if rule.TargetGroup != "commons" {
+		t.Fatalf("rewrite target_group = %q, want %q", rule.TargetGroup, "commons")
+	}
+	if rule.AuthModule != "gitlab" {
+		t.Fatalf("rewrite auth_module = %q, want %q", rule.AuthModule, "gitlab")
+	}
+}
+
 func TestSingleListenerHostDispatchConfigParses(t *testing.T) {
 	cfgText := `[server]
 address = ":9999"
@@ -244,6 +286,49 @@ base_url = "/relative"
 	_, err := initConfig(path, "TORU_")
 	if err == nil {
 		t.Fatalf("expected npm config with relative base_url to be rejected")
+	}
+}
+
+func TestNPMRewriteScopeConflictWithProtectedScopeRejected(t *testing.T) {
+	cfgText := `[server]
+address = ":9999"
+log_level = "info"
+
+[[listeners]]
+name = "npm"
+address = ":8081"
+protocols = ["npm"]
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+base_url = "https://npm.example.com"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = "gitlab.example.com"
+target_group = "commons"
+auth_module = "gitlab"
+
+[[protocols.npm.protected_scopes]]
+scope = "@example-commons"
+auth_module = "gitlab"
+`
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.toml")
+	if err := os.WriteFile(path, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"toru", "--config", path}
+
+	_, err := initConfig(path, "TORU_")
+	if err == nil {
+		t.Fatalf("expected rewrite/protected scope conflict to be rejected")
 	}
 }
 

--- a/config_compat_test.go
+++ b/config_compat_test.go
@@ -182,6 +182,71 @@ base_url = "https://npm-toru.example.com"
 	}
 }
 
+func TestNPMEnabledRequiresBaseURL(t *testing.T) {
+	cfgText := `[server]
+address = ":9999"
+log_level = "info"
+
+[[listeners]]
+name = "npm"
+address = ":8081"
+protocols = ["npm"]
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+`
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.toml")
+	if err := os.WriteFile(path, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"toru", "--config", path}
+
+	_, err := initConfig(path, "TORU_")
+	if err == nil {
+		t.Fatalf("expected npm config without base_url to be rejected")
+	}
+}
+
+func TestNPMEnabledRequiresAbsoluteBaseURL(t *testing.T) {
+	cfgText := `[server]
+address = ":9999"
+log_level = "info"
+
+[[listeners]]
+name = "npm"
+address = ":8081"
+protocols = ["npm"]
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+base_url = "/relative"
+`
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.toml")
+	if err := os.WriteFile(path, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"toru", "--config", path}
+
+	_, err := initConfig(path, "TORU_")
+	if err == nil {
+		t.Fatalf("expected npm config with relative base_url to be rejected")
+	}
+}
+
 func TestSingleListenerHostDispatchRejectsAmbiguousConfig(t *testing.T) {
 	cfgText := `[server]
 address = ":9999"

--- a/config_compat_test.go
+++ b/config_compat_test.go
@@ -3,14 +3,15 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
+	"time"
 )
 
 // Verification contract:
 // 1. Legacy Go-only config must continue to parse.
 // 2. Legacy config must normalize into explicit Go runtime semantics.
 // 3. New multi-listener config must decode into actual listener/protocol values.
+// 4. Same-listener host dispatch must require explicit host-to-protocol mapping.
 
 func TestLegacyConfigStillParsesAsGoOnly(t *testing.T) {
 	cfgText := `[server]
@@ -36,20 +37,24 @@ target_path = "github.com/example/mymodule"
 
 	cfg := loadConfigFromText(t, cfgText)
 
-	listeners := requireField(t, reflect.ValueOf(*cfg), "Listeners")
-	if listeners.Len() != 1 {
-		t.Fatalf("legacy config must synthesize exactly one Go listener, got %d", listeners.Len())
+	if len(cfg.Listeners) != 1 {
+		t.Fatalf("legacy config must synthesize exactly one Go listener, got %d", len(cfg.Listeners))
 	}
-
-	listener := listeners.Index(0)
-	address := stringField(t, listener, "Address")
-	if address != ":8888" {
-		t.Fatalf("legacy listener address = %q, want %q", address, ":8888")
+	listener := cfg.Listeners[0]
+	if listener.Name != "go" {
+		t.Fatalf("legacy listener name = %q, want %q", listener.Name, "go")
 	}
-
-	protocols := stringSliceField(t, listener, "Protocols")
-	if len(protocols) != 1 || protocols[0] != "go" {
-		t.Fatalf("legacy listener protocols = %v, want [go]", protocols)
+	if listener.Address != ":8888" {
+		t.Fatalf("legacy listener address = %q, want %q", listener.Address, ":8888")
+	}
+	if len(listener.Protocols) != 1 || listener.Protocols[0] != "go" {
+		t.Fatalf("legacy listener protocols = %v, want [go]", listener.Protocols)
+	}
+	if !cfg.Protocols.Go.Enabled {
+		t.Fatalf("legacy config must normalize to go enabled")
+	}
+	if cfg.Protocols.Go.FetchTimeout != 30*time.Second {
+		t.Fatalf("legacy go fetch timeout = %s, want 30s", cfg.Protocols.Go.FetchTimeout)
 	}
 }
 
@@ -90,49 +95,94 @@ base_url = "https://npm-toru.example.com"
 `
 
 	cfg := loadConfigFromText(t, cfgText)
-	root := reflect.ValueOf(*cfg)
-
-	listeners := requireField(t, root, "Listeners")
-	if listeners.Len() != 2 {
-		t.Fatalf("expected 2 listeners from config, got %d", listeners.Len())
+	if len(cfg.Listeners) != 2 {
+		t.Fatalf("expected 2 listeners from config, got %d", len(cfg.Listeners))
 	}
 
-	goListener := listeners.Index(0)
-	if got := stringField(t, goListener, "Name"); got != "go-public" {
-		t.Fatalf("go listener name = %q, want %q", got, "go-public")
+	goListener := cfg.Listeners[0]
+	if goListener.Name != "go-public" {
+		t.Fatalf("go listener name = %q, want %q", goListener.Name, "go-public")
 	}
-	if got := stringField(t, goListener, "Address"); got != ":8080" {
-		t.Fatalf("go listener address = %q, want %q", got, ":8080")
+	if goListener.Address != ":8080" {
+		t.Fatalf("go listener address = %q, want %q", goListener.Address, ":8080")
 	}
-	if got := stringSliceField(t, goListener, "Protocols"); len(got) != 1 || got[0] != "go" {
-		t.Fatalf("go listener protocols = %v, want [go]", got)
+	if len(goListener.Protocols) != 1 || goListener.Protocols[0] != "go" {
+		t.Fatalf("go listener protocols = %v, want [go]", goListener.Protocols)
 	}
-
-	npmListener := listeners.Index(1)
-	if got := stringField(t, npmListener, "Name"); got != "npm-public" {
-		t.Fatalf("npm listener name = %q, want %q", got, "npm-public")
-	}
-	if got := stringField(t, npmListener, "Address"); got != ":8081" {
-		t.Fatalf("npm listener address = %q, want %q", got, ":8081")
-	}
-	if got := stringSliceField(t, npmListener, "Protocols"); len(got) != 1 || got[0] != "npm" {
-		t.Fatalf("npm listener protocols = %v, want [npm]", got)
+	if len(goListener.Hosts) != 1 || goListener.Hosts[0] != "toru.example.com" {
+		t.Fatalf("go listener hosts = %v, want [toru.example.com]", goListener.Hosts)
 	}
 
-	protocols := requireField(t, root, "Protocols")
-	npmProtocol := requireField(t, protocols, "NPM")
-	if !boolField(t, npmProtocol, "Enabled") {
+	npmListener := cfg.Listeners[1]
+	if npmListener.Name != "npm-public" {
+		t.Fatalf("npm listener name = %q, want %q", npmListener.Name, "npm-public")
+	}
+	if npmListener.Address != ":8081" {
+		t.Fatalf("npm listener address = %q, want %q", npmListener.Address, ":8081")
+	}
+	if len(npmListener.Protocols) != 1 || npmListener.Protocols[0] != "npm" {
+		t.Fatalf("npm listener protocols = %v, want [npm]", npmListener.Protocols)
+	}
+	if len(npmListener.Hosts) != 1 || npmListener.Hosts[0] != "npm-toru.example.com" {
+		t.Fatalf("npm listener hosts = %v, want [npm-toru.example.com]", npmListener.Hosts)
+	}
+	if !cfg.Protocols.NPM.Enabled {
 		t.Fatalf("protocols.npm.enabled must decode to true")
 	}
-	if got := stringField(t, npmProtocol, "Upstream"); got != "https://registry.npmjs.org" {
-		t.Fatalf("protocols.npm.upstream = %q, want npm registry upstream", got)
+	if cfg.Protocols.NPM.Upstream != "https://registry.npmjs.org" {
+		t.Fatalf("protocols.npm.upstream = %q, want npm registry upstream", cfg.Protocols.NPM.Upstream)
 	}
-	if got := stringField(t, npmProtocol, "BaseURL"); got != "https://npm-toru.example.com" {
-		t.Fatalf("protocols.npm.base_url = %q, want %q", got, "https://npm-toru.example.com")
+	if cfg.Protocols.NPM.BaseURL != "https://npm-toru.example.com" {
+		t.Fatalf("protocols.npm.base_url = %q, want %q", cfg.Protocols.NPM.BaseURL, "https://npm-toru.example.com")
 	}
 }
 
-func TestMultiProtocolListenerRejectedUntilHostDispatchExists(t *testing.T) {
+func TestSingleListenerHostDispatchConfigParses(t *testing.T) {
+	cfgText := `[server]
+address = ":9999"
+log_level = "info"
+
+[[listeners]]
+name = "shared"
+address = ":8080"
+protocols = ["go", "npm"]
+hosts = ["toru.example.com", "npm-toru.example.com"]
+
+[cache]
+enabled = true
+type = "disk"
+
+[cache.disk]
+path = "/tmp/toru-cache"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = "https://registry.npmjs.org"
+metadata_ttl = "5m"
+base_url = "https://npm-toru.example.com"
+`
+
+	cfg := loadConfigFromText(t, cfgText)
+	if len(cfg.Listeners) != 1 {
+		t.Fatalf("expected 1 shared listener, got %d", len(cfg.Listeners))
+	}
+	listener := cfg.Listeners[0]
+	if listener.Name != "shared" {
+		t.Fatalf("listener name = %q, want shared", listener.Name)
+	}
+	if len(listener.Protocols) != 2 || listener.Protocols[0] != "go" || listener.Protocols[1] != "npm" {
+		t.Fatalf("listener protocols = %v, want [go npm]", listener.Protocols)
+	}
+	if len(listener.Hosts) != 2 || listener.Hosts[0] != "toru.example.com" || listener.Hosts[1] != "npm-toru.example.com" {
+		t.Fatalf("listener hosts = %v, want [toru.example.com npm-toru.example.com]", listener.Hosts)
+	}
+}
+
+func TestSingleListenerHostDispatchRejectsAmbiguousConfig(t *testing.T) {
 	cfgText := `[server]
 address = ":9999"
 log_level = "info"
@@ -141,7 +191,7 @@ log_level = "info"
 name = "mixed"
 address = ":8080"
 protocols = ["go", "npm"]
-hosts = ["toru.example.com", "npm-toru.example.com"]
+hosts = ["toru.example.com"]
 `
 
 	tmp := t.TempDir()
@@ -156,7 +206,7 @@ hosts = ["toru.example.com", "npm-toru.example.com"]
 
 	_, err := initConfig(path, "TORU_")
 	if err == nil {
-		t.Fatalf("expected multi-protocol same-listener config to be rejected until host dispatch exists")
+		t.Fatalf("expected ambiguous same-listener host-dispatch config to be rejected")
 	}
 }
 
@@ -177,50 +227,4 @@ func loadConfigFromText(t *testing.T, content string) *Config {
 		t.Fatalf("initConfig() error = %v", err)
 	}
 	return cfg
-}
-
-func requireField(t *testing.T, v reflect.Value, name string) reflect.Value {
-	t.Helper()
-	if v.Kind() == reflect.Pointer {
-		v = v.Elem()
-	}
-	field := v.FieldByName(name)
-	if !field.IsValid() {
-		t.Fatalf("expected field %q to exist", name)
-	}
-	return field
-}
-
-func stringField(t *testing.T, v reflect.Value, name string) string {
-	t.Helper()
-	field := requireField(t, v, name)
-	if field.Kind() != reflect.String {
-		t.Fatalf("field %q must be string, got %s", name, field.Kind())
-	}
-	return field.String()
-}
-
-func boolField(t *testing.T, v reflect.Value, name string) bool {
-	t.Helper()
-	field := requireField(t, v, name)
-	if field.Kind() != reflect.Bool {
-		t.Fatalf("field %q must be bool, got %s", name, field.Kind())
-	}
-	return field.Bool()
-}
-
-func stringSliceField(t *testing.T, v reflect.Value, name string) []string {
-	t.Helper()
-	field := requireField(t, v, name)
-	if field.Kind() != reflect.Slice {
-		t.Fatalf("field %q must be slice, got %s", name, field.Kind())
-	}
-	out := make([]string, field.Len())
-	for i := 0; i < field.Len(); i++ {
-		if field.Index(i).Kind() != reflect.String {
-			t.Fatalf("field %q must be []string", name)
-		}
-		out[i] = field.Index(i).String()
-	}
-	return out
 }

--- a/config_compat_test.go
+++ b/config_compat_test.go
@@ -132,6 +132,34 @@ base_url = "https://npm-toru.example.com"
 	}
 }
 
+func TestMultiProtocolListenerRejectedUntilHostDispatchExists(t *testing.T) {
+	cfgText := `[server]
+address = ":9999"
+log_level = "info"
+
+[[listeners]]
+name = "mixed"
+address = ":8080"
+protocols = ["go", "npm"]
+hosts = ["toru.example.com", "npm-toru.example.com"]
+`
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.toml")
+	if err := os.WriteFile(path, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"toru", "--config", path}
+
+	_, err := initConfig(path, "TORU_")
+	if err == nil {
+		t.Fatalf("expected multi-protocol same-listener config to be rejected until host dispatch exists")
+	}
+}
+
 func loadConfigFromText(t *testing.T, content string) *Config {
 	t.Helper()
 	tmp := t.TempDir()

--- a/main.go
+++ b/main.go
@@ -1,78 +1,24 @@
 package main
 
 import (
-	"context"
 	"log/slog"
-	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
-
-	"github.com/VictoriaMetrics/metrics"
 )
 
 var buildString = "dev"
 
 func main() {
-	// Initialize configuration
 	cfg, err := initConfig("config.toml", "TORU_")
 	if err != nil {
 		slog.Error("Error initializing config", "error", err)
 		os.Exit(1)
 	}
 
-	// Setup logger
 	logger := setupLogger(cfg.Server.LogLevel)
-
-	p, err := newProxy(cfg, logger)
-	if err != nil {
-		logger.Error("Failed to create proxy", "error", err)
+	if err := run(cfg, logger); err != nil {
+		logger.Error("Server error", "error", err)
 		os.Exit(1)
 	}
-
-	// Create a new ServeMux
-	mux := http.NewServeMux()
-
-	// Add the metrics endpoint
-	mux.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
-		metrics.WritePrometheus(w, true)
-	})
-
-	// Add the proxy handler for all other routes
-	mux.Handle("/", p)
-
-	server := &http.Server{
-		Addr:    cfg.Server.Address,
-		Handler: mux,
-	}
-
-	// Start the server in a goroutine
-	go func() {
-		logger.Info("Starting Go module proxy", "address", cfg.Server.Address)
-		if err := server.ListenAndServe(); err != http.ErrServerClosed {
-			logger.Error("Server error", "error", err)
-		}
-	}()
-
-	// Wait for interrupt signal to gracefully shutdown the server
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
-
-	logger.Info("Shutting down server gracefully...")
-
-	// Create a deadline to wait for.
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	// Doesn't block if no connections, but will otherwise wait
-	// until the timeout deadline.
-	if err := server.Shutdown(ctx); err != nil {
-		logger.Error("Server forced to shutdown", "error", err)
-	}
-
-	logger.Info("Server exited")
 }
 
 func setupLogger(level string) *slog.Logger {

--- a/metrics.go
+++ b/metrics.go
@@ -1,29 +1,52 @@
 package main
 
-import "github.com/VictoriaMetrics/metrics"
+import (
+	"fmt"
+	"time"
+
+	"github.com/VictoriaMetrics/metrics"
+)
 
 var (
-	// Total number of requests
-	requestsTotal = metrics.NewCounter("toru_requests_total")
-
-	// Request duration
-	requestDuration = metrics.NewSummary("toru_request_duration_seconds")
-
-	// Upstream fetch duration
+	// Legacy aggregate metrics
+	requestsTotal         = metrics.NewCounter("toru_requests_total")
+	requestDuration       = metrics.NewSummary("toru_request_duration_seconds")
 	upstreamFetchDuration = metrics.NewSummary("toru_upstream_fetch_duration_seconds")
-
-	// Response size
-	responseSize = metrics.NewHistogram("toru_response_size_bytes")
-
-	// Rewrite rules applied
-	rewriteRulesApplied = metrics.NewCounter("toru_rewrite_rules_applied_total")
-
-	// Errors encountered
-	errorsTotal = metrics.NewCounter("toru_errors_total")
-
-	// Cache metrics
-	cacheHits   = metrics.NewCounter("toru_cache_hits_total")
-	cacheMisses = metrics.NewCounter("toru_cache_misses_total")
-	cacheWrites = metrics.NewCounter("toru_cache_writes_total")
-	cacheErrors = metrics.NewCounter("toru_cache_errors_total")
+	responseSize          = metrics.NewHistogram("toru_response_size_bytes")
+	rewriteRulesApplied   = metrics.NewCounter("toru_rewrite_rules_applied_total")
+	errorsTotal           = metrics.NewCounter("toru_errors_total")
+	cacheHits             = metrics.NewCounter("toru_cache_hits_total")
+	cacheMisses           = metrics.NewCounter("toru_cache_misses_total")
+	cacheWrites           = metrics.NewCounter("toru_cache_writes_total")
+	cacheErrors           = metrics.NewCounter("toru_cache_errors_total")
 )
+
+func recordProtocolRequest(protocol, kind string, duration time.Duration, size int) {
+	requestsTotal.Inc()
+	requestDuration.UpdateDuration(time.Now().Add(-duration))
+	responseSize.Update(float64(size))
+
+	metrics.GetOrCreateCounter(fmt.Sprintf(`toru_requests_by_protocol_total{protocol=%q,kind=%q}`, protocol, kind)).Inc()
+	metrics.GetOrCreateSummary(fmt.Sprintf(`toru_request_duration_by_protocol_seconds{protocol=%q,kind=%q}`, protocol, kind)).UpdateDuration(time.Now().Add(-duration))
+	metrics.GetOrCreateHistogram(fmt.Sprintf(`toru_response_size_by_protocol_bytes{protocol=%q,kind=%q}`, protocol, kind)).Update(float64(size))
+}
+
+func recordProtocolCacheHit(protocol, class string) {
+	cacheHits.Inc()
+	metrics.GetOrCreateCounter(fmt.Sprintf(`toru_cache_hits_by_protocol_total{protocol=%q,class=%q}`, protocol, class)).Inc()
+}
+
+func recordProtocolCacheMiss(protocol, class string) {
+	cacheMisses.Inc()
+	metrics.GetOrCreateCounter(fmt.Sprintf(`toru_cache_misses_by_protocol_total{protocol=%q,class=%q}`, protocol, class)).Inc()
+}
+
+func recordProtocolCacheWrite(protocol, class string) {
+	cacheWrites.Inc()
+	metrics.GetOrCreateCounter(fmt.Sprintf(`toru_cache_writes_by_protocol_total{protocol=%q,class=%q}`, protocol, class)).Inc()
+}
+
+func recordProtocolCacheError(protocol, class string) {
+	cacheErrors.Inc()
+	metrics.GetOrCreateCounter(fmt.Sprintf(`toru_cache_errors_by_protocol_total{protocol=%q,class=%q}`, protocol, class)).Inc()
+}

--- a/npm.go
+++ b/npm.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -207,14 +209,18 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		_, gitlabToken, _ = authorizeRequestToken(r, rule.AuthModule)
 		cacheKey := h.rewriteTarballCacheKey(rule, pkg, filename)
 		if cacheKey != "" {
-			if body, _, ok := h.readCacheBytes(cacheKey); ok {
+			if body, _, ok, err := h.readCacheBytes(cacheKey); err == nil && ok {
 				recordProtocolCacheHit("npm", "artifact")
 				w.Header().Set("Content-Type", "application/octet-stream")
 				finalSize = len(body)
 				_, _ = w.Write(body)
 				return
+			} else if err != nil {
+				h.logger.Error("failed to read npm cache body; falling back to uncached fetch", "key", cacheKey, "error", err)
+				recordProtocolCacheError("npm", "artifact")
+			} else {
+				recordProtocolCacheMiss("npm", "artifact")
 			}
-			recordProtocolCacheMiss("npm", "artifact")
 		}
 		body, statusCode, err := h.synthesizeRewrittenTarball(r, pkg, filename, rule, gitlabToken)
 		if err != nil {
@@ -246,14 +252,18 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 
 	cacheKey := h.tarballCacheKey(pkg, filename)
 	if cacheKey != "" {
-		if body, _, ok := h.readCacheBytes(cacheKey); ok {
+		if body, _, ok, err := h.readCacheBytes(cacheKey); err == nil && ok {
 			recordProtocolCacheHit("npm", "artifact")
 			w.Header().Set("Content-Type", "application/octet-stream")
 			finalSize = len(body)
 			_, _ = w.Write(body)
 			return
+		} else if err != nil {
+			h.logger.Error("failed to read npm cache body; falling back to uncached fetch", "key", cacheKey, "error", err)
+			recordProtocolCacheError("npm", "artifact")
+		} else {
+			recordProtocolCacheMiss("npm", "artifact")
 		}
-		recordProtocolCacheMiss("npm", "artifact")
 	}
 
 	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + pkg + "/-/" + filename
@@ -395,15 +405,18 @@ func (h *npmHandler) rewriteTarballCacheKey(rule NPMRewriteRule, pkg, filename s
 	return filepath.ToSlash(filepath.Join("npm-rewrite", hostKey, groupKey, npmCachePackageKey(pkg), filename))
 }
 
-func (h *npmHandler) readCacheBytes(key string) ([]byte, time.Time, bool) {
+func (h *npmHandler) readCacheBytes(key string) ([]byte, time.Time, bool, error) {
 	if h.npmCache == nil || key == "" {
-		return nil, time.Time{}, false
+		return nil, time.Time{}, false, nil
 	}
 	body, modifiedAt, err := h.npmCache.Get(key)
 	if err != nil {
-		return nil, time.Time{}, false
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, time.Time{}, false, nil
+		}
+		return nil, time.Time{}, false, err
 	}
-	return body, modifiedAt, true
+	return body, modifiedAt, true, nil
 }
 
 func (h *npmHandler) writeCacheBytes(key string, body []byte) error {
@@ -424,11 +437,21 @@ func (h *npmHandler) readMetadataCache(pkg string) (metadataCacheEntry, bool) {
 	if !h.metadataCacheEnabled() {
 		return metadataCacheEntry{}, false
 	}
-	body, modifiedAt, ok := h.readCacheBytes(h.metadataCacheKey(pkg))
+	body, modifiedAt, ok, err := h.readCacheBytes(h.metadataCacheKey(pkg))
+	if err != nil {
+		h.logger.Error("failed to read npm metadata cache body; falling back to upstream fetch", "key", h.metadataCacheKey(pkg), "error", err)
+		recordProtocolCacheError("npm", "metadata")
+		return metadataCacheEntry{}, false
+	}
 	if !ok {
 		return metadataCacheEntry{}, false
 	}
-	etagBytes, _, _ := h.readCacheBytes(h.metadataETagKey(pkg))
+	etagBytes, _, _, err := h.readCacheBytes(h.metadataETagKey(pkg))
+	if err != nil {
+		h.logger.Error("failed to read npm metadata etag cache body; continuing without etag", "key", h.metadataETagKey(pkg), "error", err)
+		recordProtocolCacheError("npm", "metadata")
+		etagBytes = nil
+	}
 	expiresAt := modifiedAt.Add(h.cfg.Protocols.NPM.MetadataTTL)
 	if cachedExpiry, ok := h.readMetadataExpiry(pkg); ok {
 		expiresAt = cachedExpiry
@@ -466,7 +489,12 @@ func (h *npmHandler) writeMetadataCache(pkg string, body []byte, etag string) (b
 }
 
 func (h *npmHandler) readMetadataExpiry(pkg string) (time.Time, bool) {
-	b, _, ok := h.readCacheBytes(h.metadataExpiryKey(pkg))
+	b, _, ok, err := h.readCacheBytes(h.metadataExpiryKey(pkg))
+	if err != nil {
+		h.logger.Error("failed to read npm metadata expiry cache body; treating cache entry as stale", "key", h.metadataExpiryKey(pkg), "error", err)
+		recordProtocolCacheError("npm", "metadata")
+		return time.Time{}, false
+	}
 	if !ok {
 		return time.Time{}, false
 	}

--- a/npm.go
+++ b/npm.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"log/slog"
+)
+
+type npmHandler struct {
+	cfg    *Config
+	logger *slog.Logger
+}
+
+func newNPMHandler(cfg *Config, logger *slog.Logger) http.Handler {
+	return &npmHandler{cfg: cfg, logger: logger.With("component", "npm")}
+}
+
+func (h *npmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if strings.Contains(r.URL.Path, "/-/") {
+		h.handleTarball(w, r)
+		return
+	}
+	h.handleMetadata(w, r)
+}
+
+func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
+	pkg := decodeNPMPackagePath(r.URL.Path)
+	if pkg == "" {
+		http.Error(w, "invalid package path", http.StatusBadRequest)
+		return
+	}
+	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + pkg
+	resp, err := http.Get(upstreamURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		w.WriteHeader(resp.StatusCode)
+		_, _ = w.Write(body)
+		return
+	}
+	rewritten, err := rewriteNPMMetadataTarballs(body, h.cfg.Protocols.NPM.BaseURL, pkg)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(rewritten)
+}
+
+func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
+	pkg, filename := parseNPMTarballPath(r.URL.Path)
+	if pkg == "" || filename == "" {
+		http.Error(w, "invalid tarball path", http.StatusBadRequest)
+		return
+	}
+	cachePath := filepath.Join(h.cfg.Cache.Disk.Path, "npm", strings.ReplaceAll(pkg, "/", "__"), filename)
+	if body, err := os.ReadFile(cachePath); err == nil {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(body)
+		return
+	}
+	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + r.URL.Path
+	resp, err := http.Get(upstreamURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		w.WriteHeader(resp.StatusCode)
+		_, _ = w.Write(body)
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(cachePath), 0o755)
+	_ = os.WriteFile(cachePath, body, 0o644)
+	w.Header().Set("Content-Type", "application/octet-stream")
+	_, _ = w.Write(body)
+}
+
+func decodeNPMPackagePath(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	path = strings.ReplaceAll(path, "%2F", "/")
+	path = strings.ReplaceAll(path, "%2f", "/")
+	path = strings.ReplaceAll(path, "%40", "@")
+	path = strings.ReplaceAll(path, "%40", "@")
+	return path
+}
+
+func parseNPMTarballPath(path string) (string, string) {
+	trimmed := strings.TrimPrefix(path, "/")
+	idx := strings.Index(trimmed, "/-/")
+	if idx < 0 {
+		return "", ""
+	}
+	pkg := decodeNPMPackagePath(trimmed[:idx])
+	return pkg, trimmed[idx+3:]
+}
+
+func rewriteNPMMetadataTarballs(body []byte, baseURL, packageName string) ([]byte, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, err
+	}
+	versions, _ := doc["versions"].(map[string]any)
+	for _, value := range versions {
+		vm, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		dist, ok := vm["dist"].(map[string]any)
+		if !ok {
+			continue
+		}
+		tarball, ok := dist["tarball"].(string)
+		if !ok {
+			continue
+		}
+		parts := strings.Split(tarball, "/")
+		filename := parts[len(parts)-1]
+		dist["tarball"] = fmt.Sprintf("%s/%s/-/%s", strings.TrimSuffix(baseURL, "/"), packageName, filename)
+	}
+	return json.Marshal(doc)
+}

--- a/npm.go
+++ b/npm.go
@@ -49,6 +49,18 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid package path", http.StatusBadRequest)
 		return
 	}
+
+	if body, ok := h.readFreshMetadataCache(pkg); ok {
+		rewritten, err := rewriteNPMMetadataTarballs(body, h.cfg.Protocols.NPM.BaseURL, pkg)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(rewritten)
+		return
+	}
+
 	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + encodeNPMPackagePath(pkg)
 	resp, body, err := h.doUpstreamGet(r, upstreamURL)
 	if err != nil {
@@ -61,6 +73,7 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(body)
 		return
 	}
+	_ = h.writeMetadataCache(pkg, body)
 	rewritten, err := rewriteNPMMetadataTarballs(body, h.cfg.Protocols.NPM.BaseURL, pkg)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -155,6 +168,49 @@ func parseNPMTarballPath(path string) (string, string) {
 	}
 	pkg := decodeNPMPackagePath(trimmed[:idx])
 	return pkg, trimmed[idx+3:]
+}
+
+func (h *npmHandler) metadataCacheEnabled() bool {
+	return h.cfg.Cache.Enabled && h.cfg.Cache.Type == "disk" && h.cfg.Cache.Disk.Path != "" && h.cfg.Protocols.NPM.MetadataTTL > 0
+}
+
+func (h *npmHandler) metadataCachePath(pkg string) string {
+	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".json")
+}
+
+func (h *npmHandler) readFreshMetadataCache(pkg string) ([]byte, bool) {
+	if !h.metadataCacheEnabled() {
+		return nil, false
+	}
+	path := h.metadataCachePath(pkg)
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, false
+	}
+	if time.Since(info.ModTime()) > h.cfg.Protocols.NPM.MetadataTTL {
+		return nil, false
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+func (h *npmHandler) writeMetadataCache(pkg string, body []byte) error {
+	if !h.metadataCacheEnabled() {
+		return nil
+	}
+	path := h.metadataCachePath(pkg)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		h.logger.Error("failed to create npm metadata cache directory; serving uncached body", "path", filepath.Dir(path), "error", err)
+		return err
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		h.logger.Error("failed to write npm metadata cache file; serving uncached body", "path", path, "error", err)
+		return err
+	}
+	return nil
 }
 
 func rewriteNPMMetadataTarballs(body []byte, baseURL, packageName string) ([]byte, error) {

--- a/npm.go
+++ b/npm.go
@@ -76,14 +76,14 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid tarball path", http.StatusBadRequest)
 		return
 	}
-	cachePath := filepath.Join(h.cfg.Cache.Disk.Path, "npm", strings.ReplaceAll(pkg, "/", "__"), filename)
+	cachePath := filepath.Join(h.cfg.Cache.Disk.Path, "npm", npmCachePackageKey(pkg), filename)
 	if body, err := os.ReadFile(cachePath); err == nil {
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = w.Write(body)
 		return
 	}
 
-	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + encodeNPMPackagePath(pkg) + "/-/" + filename
+	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + pkg + "/-/" + filename
 	resp, body, err := h.doUpstreamGet(r, upstreamURL)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -96,13 +96,15 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
-		h.logger.Error("failed to create npm cache directory", "path", filepath.Dir(cachePath), "error", err)
-		http.Error(w, "failed to create npm cache directory", http.StatusInternalServerError)
+		h.logger.Error("failed to create npm cache directory; serving uncached body", "path", filepath.Dir(cachePath), "error", err)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(body)
 		return
 	}
 	if err := os.WriteFile(cachePath, body, 0o644); err != nil {
-		h.logger.Error("failed to write npm cache file", "path", cachePath, "error", err)
-		http.Error(w, "failed to write npm cache file", http.StatusInternalServerError)
+		h.logger.Error("failed to write npm cache file; serving uncached body", "path", cachePath, "error", err)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(body)
 		return
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")
@@ -139,6 +141,10 @@ func decodeNPMPackagePath(path string) string {
 func encodeNPMPackagePath(pkg string) string {
 	encoded := url.PathEscape(pkg)
 	return strings.ReplaceAll(encoded, "@", "%40")
+}
+
+func npmCachePackageKey(pkg string) string {
+	return encodeNPMPackagePath(pkg)
 }
 
 func parseNPMTarballPath(path string) (string, string) {

--- a/npm.go
+++ b/npm.go
@@ -196,7 +196,46 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg, Scope: rule.Scope, RepoPath: repoPath}) {
 			return
 		}
-		http.Error(w, "npm rewrite tarballs are not implemented yet", http.StatusNotImplemented)
+		gitlabToken := ""
+		_, gitlabToken, _ = authorizeRequestToken(r, rule.AuthModule)
+		cachePath := h.rewriteTarballCachePath(rule, pkg, filename)
+		if cachePath != "" {
+			if body, err := os.ReadFile(cachePath); err == nil {
+				recordProtocolCacheHit("npm", "artifact")
+				w.Header().Set("Content-Type", "application/octet-stream")
+				finalSize = len(body)
+				_, _ = w.Write(body)
+				return
+			}
+			recordProtocolCacheMiss("npm", "artifact")
+		}
+		body, statusCode, err := h.synthesizeRewrittenTarball(r, pkg, filename, rule, gitlabToken)
+		if err != nil {
+			http.Error(w, err.Error(), statusCode)
+			return
+		}
+		if cachePath != "" {
+			if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+				h.logger.Error("failed to create npm cache directory; serving uncached body", "path", filepath.Dir(cachePath), "error", err)
+				recordProtocolCacheError("npm", "artifact")
+				w.Header().Set("Content-Type", "application/octet-stream")
+				finalSize = len(body)
+				_, _ = w.Write(body)
+				return
+			}
+			if err := os.WriteFile(cachePath, body, 0o644); err != nil {
+				h.logger.Error("failed to write npm cache file; serving uncached body", "path", cachePath, "error", err)
+				recordProtocolCacheError("npm", "artifact")
+				w.Header().Set("Content-Type", "application/octet-stream")
+				finalSize = len(body)
+				_, _ = w.Write(body)
+				return
+			}
+			recordProtocolCacheWrite("npm", "artifact")
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		finalSize = len(body)
+		_, _ = w.Write(body)
 		return
 	}
 
@@ -333,6 +372,16 @@ func (h *npmHandler) tarballCachePath(pkg, filename string) string {
 		return ""
 	}
 	return filepath.Join(h.cfg.Cache.Disk.Path, "npm", npmCachePackageKey(pkg), filename)
+}
+
+func (h *npmHandler) rewriteTarballCachePath(rule NPMRewriteRule, pkg, filename string) string {
+	if !h.artifactCacheEnabled() {
+		return ""
+	}
+	hostKey := strings.TrimSpace(rule.TargetHost)
+	hostKey = strings.ReplaceAll(hostKey, ":", "_")
+	groupKey := strings.ReplaceAll(normalizeTargetGroup(rule.TargetGroup), "/", "__")
+	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-rewrite", hostKey, groupKey, npmCachePackageKey(pkg), filename)
 }
 
 func (h *npmHandler) readMetadataCache(pkg string) (metadataCacheEntry, bool) {

--- a/npm.go
+++ b/npm.go
@@ -20,6 +20,12 @@ type npmHandler struct {
 	authenticators map[string]Authenticator
 }
 
+type metadataCacheEntry struct {
+	Body  []byte
+	ETag  string
+	Fresh bool
+}
+
 func newNPMHandler(cfg *Config, logger *slog.Logger, authenticators map[string]Authenticator) http.Handler {
 	timeout := cfg.Server.FetchTimeout
 	if timeout == 0 {
@@ -63,17 +69,57 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if body, ok := h.readFreshMetadataCache(pkg); ok {
-		recordProtocolCacheHit("npm", "metadata")
-		rewritten, err := rewriteNPMMetadataTarballs(body, h.cfg.Protocols.NPM.BaseURL, pkg)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+	if entry, ok := h.readMetadataCache(pkg); ok {
+		if entry.Fresh {
+			recordProtocolCacheHit("npm", "metadata")
+			rewritten, err := rewriteNPMMetadataTarballs(entry.Body, h.cfg.Protocols.NPM.BaseURL, pkg)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			finalSize = len(rewritten)
+			_, _ = w.Write(rewritten)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		finalSize = len(rewritten)
-		_, _ = w.Write(rewritten)
-		return
+
+		if entry.ETag != "" {
+			revalidated, statusCode, err := h.revalidateMetadataCache(r, pkg, entry)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			switch statusCode {
+			case http.StatusNotModified:
+				recordProtocolCacheHit("npm", "metadata")
+				rewritten, err := rewriteNPMMetadataTarballs(revalidated.Body, h.cfg.Protocols.NPM.BaseURL, pkg)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadGateway)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				finalSize = len(rewritten)
+				_, _ = w.Write(rewritten)
+				return
+			case http.StatusOK:
+				recordProtocolCacheMiss("npm", "metadata")
+				rewritten, err := rewriteNPMMetadataTarballs(revalidated.Body, h.cfg.Protocols.NPM.BaseURL, pkg)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadGateway)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				finalSize = len(rewritten)
+				_, _ = w.Write(rewritten)
+				return
+			default:
+				recordProtocolCacheMiss("npm", "metadata")
+				w.WriteHeader(statusCode)
+				finalSize = len(revalidated.Body)
+				_, _ = w.Write(revalidated.Body)
+				return
+			}
+		}
 	}
 
 	recordProtocolCacheMiss("npm", "metadata")
@@ -90,7 +136,7 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(body)
 		return
 	}
-	wroteMetadataCache, err := h.writeMetadataCache(pkg, body)
+	wroteMetadataCache, err := h.writeMetadataCache(pkg, body, resp.Header.Get("ETag"))
 	if err == nil {
 		if wroteMetadataCache {
 			recordProtocolCacheWrite("npm", "metadata")
@@ -233,6 +279,10 @@ func (h *npmHandler) metadataCachePath(pkg string) string {
 	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".json")
 }
 
+func (h *npmHandler) metadataETagPath(pkg string) string {
+	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".etag")
+}
+
 func (h *npmHandler) tarballCachePath(pkg, filename string) string {
 	if !h.artifactCacheEnabled() {
 		return ""
@@ -240,26 +290,28 @@ func (h *npmHandler) tarballCachePath(pkg, filename string) string {
 	return filepath.Join(h.cfg.Cache.Disk.Path, "npm", npmCachePackageKey(pkg), filename)
 }
 
-func (h *npmHandler) readFreshMetadataCache(pkg string) ([]byte, bool) {
+func (h *npmHandler) readMetadataCache(pkg string) (metadataCacheEntry, bool) {
 	if !h.metadataCacheEnabled() {
-		return nil, false
+		return metadataCacheEntry{}, false
 	}
 	path := h.metadataCachePath(pkg)
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, false
-	}
-	if time.Since(info.ModTime()) > h.cfg.Protocols.NPM.MetadataTTL {
-		return nil, false
+		return metadataCacheEntry{}, false
 	}
 	body, err := os.ReadFile(path)
 	if err != nil {
-		return nil, false
+		return metadataCacheEntry{}, false
 	}
-	return body, true
+	etagBytes, _ := os.ReadFile(h.metadataETagPath(pkg))
+	return metadataCacheEntry{
+		Body:  body,
+		ETag:  string(etagBytes),
+		Fresh: time.Since(info.ModTime()) <= h.cfg.Protocols.NPM.MetadataTTL,
+	}, true
 }
 
-func (h *npmHandler) writeMetadataCache(pkg string, body []byte) (bool, error) {
+func (h *npmHandler) writeMetadataCache(pkg string, body []byte, etag string) (bool, error) {
 	if !h.metadataCacheEnabled() {
 		return false, nil
 	}
@@ -272,7 +324,54 @@ func (h *npmHandler) writeMetadataCache(pkg string, body []byte) (bool, error) {
 		h.logger.Error("failed to write npm metadata cache file; serving uncached body", "path", path, "error", err)
 		return false, err
 	}
+	etagPath := h.metadataETagPath(pkg)
+	if etag != "" {
+		if err := os.WriteFile(etagPath, []byte(etag), 0o644); err != nil {
+			h.logger.Error("failed to write npm metadata etag file; serving uncached body", "path", etagPath, "error", err)
+			return false, err
+		}
+	} else {
+		_ = os.Remove(etagPath)
+	}
 	return true, nil
+}
+
+func (h *npmHandler) revalidateMetadataCache(r *http.Request, pkg string, entry metadataCacheEntry) (metadataCacheEntry, int, error) {
+	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + encodeNPMPackagePath(pkg)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstreamURL, nil)
+	if err != nil {
+		return metadataCacheEntry{}, 0, err
+	}
+	req.Header.Set("If-None-Match", entry.ETag)
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return metadataCacheEntry{}, 0, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return metadataCacheEntry{}, 0, err
+	}
+	if resp.StatusCode == http.StatusNotModified {
+		path := h.metadataCachePath(pkg)
+		now := time.Now()
+		if err := os.Chtimes(path, now, now); err != nil {
+			return metadataCacheEntry{}, 0, err
+		}
+		etagPath := h.metadataETagPath(pkg)
+		if _, err := os.Stat(etagPath); err == nil {
+			_ = os.Chtimes(etagPath, now, now)
+		}
+		return metadataCacheEntry{Body: entry.Body, ETag: entry.ETag, Fresh: true}, http.StatusNotModified, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return metadataCacheEntry{Body: body}, resp.StatusCode, nil
+	}
+	_, err = h.writeMetadataCache(pkg, body, resp.Header.Get("ETag"))
+	if err != nil {
+		return metadataCacheEntry{}, 0, err
+	}
+	return metadataCacheEntry{Body: body, ETag: resp.Header.Get("ETag"), Fresh: true}, http.StatusOK, nil
 }
 
 func rewriteNPMMetadataTarballs(body []byte, baseURL, packageName string) ([]byte, error) {

--- a/npm.go
+++ b/npm.go
@@ -46,11 +46,16 @@ func (h *npmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
+	startTime := time.Now()
 	pkg := decodeNPMPackagePath(r.URL.Path)
+	finalSize := 0
+	defer func() { recordProtocolRequest("npm", "metadata", time.Since(startTime), finalSize) }()
+
 	if pkg == "" {
 		http.Error(w, "invalid package path", http.StatusBadRequest)
 		return
 	}
+	h.logger.Info("Received request", "protocol", "npm", "kind", "metadata", "method", r.Method, "path", r.URL.Path, "package", pkg)
 
 	if rule, ok := matchProtectedScope(h.cfg.Protocols.NPM.ProtectedScopes, pkg); ok {
 		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg}) {
@@ -59,16 +64,19 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if body, ok := h.readFreshMetadataCache(pkg); ok {
+		recordProtocolCacheHit("npm", "metadata")
 		rewritten, err := rewriteNPMMetadataTarballs(body, h.cfg.Protocols.NPM.BaseURL, pkg)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
+		finalSize = len(rewritten)
 		_, _ = w.Write(rewritten)
 		return
 	}
 
+	recordProtocolCacheMiss("npm", "metadata")
 	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + encodeNPMPackagePath(pkg)
 	resp, body, err := h.doUpstreamGet(r, upstreamURL)
 	if err != nil {
@@ -78,36 +86,56 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		w.WriteHeader(resp.StatusCode)
+		finalSize = len(body)
 		_, _ = w.Write(body)
 		return
 	}
-	_ = h.writeMetadataCache(pkg, body)
+	wroteMetadataCache, err := h.writeMetadataCache(pkg, body)
+	if err == nil {
+		if wroteMetadataCache {
+			recordProtocolCacheWrite("npm", "metadata")
+		}
+	} else {
+		recordProtocolCacheError("npm", "metadata")
+	}
 	rewritten, err := rewriteNPMMetadataTarballs(body, h.cfg.Protocols.NPM.BaseURL, pkg)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+	finalSize = len(rewritten)
 	_, _ = w.Write(rewritten)
 }
 
 func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
+	startTime := time.Now()
 	pkg, filename := parseNPMTarballPath(r.URL.Path)
+	finalSize := 0
+	defer func() { recordProtocolRequest("npm", "artifact", time.Since(startTime), finalSize) }()
+
 	if pkg == "" || filename == "" {
 		http.Error(w, "invalid tarball path", http.StatusBadRequest)
 		return
 	}
+	h.logger.Info("Received request", "protocol", "npm", "kind", "artifact", "method", r.Method, "path", r.URL.Path, "package", pkg, "filename", filename)
+
 	if rule, ok := matchProtectedScope(h.cfg.Protocols.NPM.ProtectedScopes, pkg); ok {
 		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg}) {
 			return
 		}
 	}
 
-	cachePath := filepath.Join(h.cfg.Cache.Disk.Path, "npm", npmCachePackageKey(pkg), filename)
-	if body, err := os.ReadFile(cachePath); err == nil {
-		w.Header().Set("Content-Type", "application/octet-stream")
-		_, _ = w.Write(body)
-		return
+	cachePath := h.tarballCachePath(pkg, filename)
+	if cachePath != "" {
+		if body, err := os.ReadFile(cachePath); err == nil {
+			recordProtocolCacheHit("npm", "artifact")
+			w.Header().Set("Content-Type", "application/octet-stream")
+			finalSize = len(body)
+			_, _ = w.Write(body)
+			return
+		}
+		recordProtocolCacheMiss("npm", "artifact")
 	}
 
 	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + pkg + "/-/" + filename
@@ -119,22 +147,31 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		w.WriteHeader(resp.StatusCode)
+		finalSize = len(body)
 		_, _ = w.Write(body)
 		return
 	}
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
-		h.logger.Error("failed to create npm cache directory; serving uncached body", "path", filepath.Dir(cachePath), "error", err)
-		w.Header().Set("Content-Type", "application/octet-stream")
-		_, _ = w.Write(body)
-		return
-	}
-	if err := os.WriteFile(cachePath, body, 0o644); err != nil {
-		h.logger.Error("failed to write npm cache file; serving uncached body", "path", cachePath, "error", err)
-		w.Header().Set("Content-Type", "application/octet-stream")
-		_, _ = w.Write(body)
-		return
+	if cachePath != "" {
+		if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+			h.logger.Error("failed to create npm cache directory; serving uncached body", "path", filepath.Dir(cachePath), "error", err)
+			recordProtocolCacheError("npm", "artifact")
+			w.Header().Set("Content-Type", "application/octet-stream")
+			finalSize = len(body)
+			_, _ = w.Write(body)
+			return
+		}
+		if err := os.WriteFile(cachePath, body, 0o644); err != nil {
+			h.logger.Error("failed to write npm cache file; serving uncached body", "path", cachePath, "error", err)
+			recordProtocolCacheError("npm", "artifact")
+			w.Header().Set("Content-Type", "application/octet-stream")
+			finalSize = len(body)
+			_, _ = w.Write(body)
+			return
+		}
+		recordProtocolCacheWrite("npm", "artifact")
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")
+	finalSize = len(body)
 	_, _ = w.Write(body)
 }
 
@@ -188,8 +225,19 @@ func (h *npmHandler) metadataCacheEnabled() bool {
 	return h.cfg.Cache.Enabled && h.cfg.Cache.Type == "disk" && h.cfg.Cache.Disk.Path != "" && h.cfg.Protocols.NPM.MetadataTTL > 0
 }
 
+func (h *npmHandler) artifactCacheEnabled() bool {
+	return h.cfg.Cache.Enabled && h.cfg.Cache.Type == "disk" && h.cfg.Cache.Disk.Path != ""
+}
+
 func (h *npmHandler) metadataCachePath(pkg string) string {
 	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".json")
+}
+
+func (h *npmHandler) tarballCachePath(pkg, filename string) string {
+	if !h.artifactCacheEnabled() {
+		return ""
+	}
+	return filepath.Join(h.cfg.Cache.Disk.Path, "npm", npmCachePackageKey(pkg), filename)
 }
 
 func (h *npmHandler) readFreshMetadataCache(pkg string) ([]byte, bool) {
@@ -211,20 +259,20 @@ func (h *npmHandler) readFreshMetadataCache(pkg string) ([]byte, bool) {
 	return body, true
 }
 
-func (h *npmHandler) writeMetadataCache(pkg string, body []byte) error {
+func (h *npmHandler) writeMetadataCache(pkg string, body []byte) (bool, error) {
 	if !h.metadataCacheEnabled() {
-		return nil
+		return false, nil
 	}
 	path := h.metadataCachePath(pkg)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		h.logger.Error("failed to create npm metadata cache directory; serving uncached body", "path", filepath.Dir(path), "error", err)
-		return err
+		return false, err
 	}
 	if err := os.WriteFile(path, body, 0o644); err != nil {
 		h.logger.Error("failed to write npm metadata cache file; serving uncached body", "path", path, "error", err)
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }
 
 func rewriteNPMMetadataTarballs(body []byte, baseURL, packageName string) ([]byte, error) {

--- a/npm.go
+++ b/npm.go
@@ -4,21 +4,31 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"log/slog"
+	"time"
 )
 
 type npmHandler struct {
-	cfg    *Config
-	logger *slog.Logger
+	cfg        *Config
+	logger     *slog.Logger
+	httpClient *http.Client
 }
 
 func newNPMHandler(cfg *Config, logger *slog.Logger) http.Handler {
-	return &npmHandler{cfg: cfg, logger: logger.With("component", "npm")}
+	timeout := cfg.Server.FetchTimeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	return &npmHandler{
+		cfg:        cfg,
+		logger:     logger.With("component", "npm"),
+		httpClient: &http.Client{Timeout: timeout},
+	}
 }
 
 func (h *npmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -39,18 +49,13 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid package path", http.StatusBadRequest)
 		return
 	}
-	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + pkg
-	resp, err := http.Get(upstreamURL)
+	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + encodeNPMPackagePath(pkg)
+	resp, body, err := h.doUpstreamGet(r, upstreamURL)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
-	}
 	if resp.StatusCode != http.StatusOK {
 		w.WriteHeader(resp.StatusCode)
 		_, _ = w.Write(body)
@@ -77,36 +82,63 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(body)
 		return
 	}
-	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + r.URL.Path
-	resp, err := http.Get(upstreamURL)
+
+	upstreamURL := strings.TrimSuffix(h.cfg.Protocols.NPM.Upstream, "/") + "/" + encodeNPMPackagePath(pkg) + "/-/" + filename
+	resp, body, err := h.doUpstreamGet(r, upstreamURL)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
-	}
 	if resp.StatusCode != http.StatusOK {
 		w.WriteHeader(resp.StatusCode)
 		_, _ = w.Write(body)
 		return
 	}
-	_ = os.MkdirAll(filepath.Dir(cachePath), 0o755)
-	_ = os.WriteFile(cachePath, body, 0o644)
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		h.logger.Error("failed to create npm cache directory", "path", filepath.Dir(cachePath), "error", err)
+		http.Error(w, "failed to create npm cache directory", http.StatusInternalServerError)
+		return
+	}
+	if err := os.WriteFile(cachePath, body, 0o644); err != nil {
+		h.logger.Error("failed to write npm cache file", "path", cachePath, "error", err)
+		http.Error(w, "failed to write npm cache file", http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/octet-stream")
 	_, _ = w.Write(body)
 }
 
+func (h *npmHandler) doUpstreamGet(r *http.Request, upstreamURL string) (*http.Response, []byte, error) {
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstreamURL, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		return nil, nil, err
+	}
+	resp.Body = io.NopCloser(strings.NewReader(string(body)))
+	return resp, body, nil
+}
+
 func decodeNPMPackagePath(path string) string {
 	path = strings.TrimPrefix(path, "/")
-	path = strings.ReplaceAll(path, "%2F", "/")
-	path = strings.ReplaceAll(path, "%2f", "/")
-	path = strings.ReplaceAll(path, "%40", "@")
-	path = strings.ReplaceAll(path, "%40", "@")
-	return path
+	decoded, err := url.PathUnescape(path)
+	if err != nil {
+		return path
+	}
+	return decoded
+}
+
+func encodeNPMPackagePath(pkg string) string {
+	encoded := url.PathEscape(pkg)
+	return strings.ReplaceAll(encoded, "@", "%40")
 }
 
 func parseNPMTarballPath(path string) (string, string) {
@@ -124,6 +156,7 @@ func rewriteNPMMetadataTarballs(body []byte, baseURL, packageName string) ([]byt
 	if err := json.Unmarshal(body, &doc); err != nil {
 		return nil, err
 	}
+	encodedPackageName := encodeNPMPackagePath(packageName)
 	versions, _ := doc["versions"].(map[string]any)
 	for _, value := range versions {
 		vm, ok := value.(map[string]any)
@@ -140,7 +173,7 @@ func rewriteNPMMetadataTarballs(body []byte, baseURL, packageName string) ([]byt
 		}
 		parts := strings.Split(tarball, "/")
 		filename := parts[len(parts)-1]
-		dist["tarball"] = fmt.Sprintf("%s/%s/-/%s", strings.TrimSuffix(baseURL, "/"), packageName, filename)
+		dist["tarball"] = fmt.Sprintf("%s/%s/-/%s", strings.TrimSuffix(baseURL, "/"), encodedPackageName, filename)
 	}
 	return json.Marshal(doc)
 }

--- a/npm.go
+++ b/npm.go
@@ -21,9 +21,10 @@ type npmHandler struct {
 }
 
 type metadataCacheEntry struct {
-	Body  []byte
-	ETag  string
-	Fresh bool
+	Body      []byte
+	ETag      string
+	ExpiresAt time.Time
+	Fresh     bool
 }
 
 func newNPMHandler(cfg *Config, logger *slog.Logger, authenticators map[string]Authenticator) http.Handler {
@@ -64,7 +65,7 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("Received request", "protocol", "npm", "kind", "metadata", "method", r.Method, "path", r.URL.Path, "package", pkg)
 
 	if rule, ok := matchProtectedScope(h.cfg.Protocols.NPM.ProtectedScopes, pkg); ok {
-		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg}) {
+		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg, Scope: rule.Scope}) {
 			return
 		}
 	}
@@ -167,7 +168,7 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("Received request", "protocol", "npm", "kind", "artifact", "method", r.Method, "path", r.URL.Path, "package", pkg, "filename", filename)
 
 	if rule, ok := matchProtectedScope(h.cfg.Protocols.NPM.ProtectedScopes, pkg); ok {
-		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg}) {
+		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg, Scope: rule.Scope}) {
 			return
 		}
 	}
@@ -283,6 +284,10 @@ func (h *npmHandler) metadataETagPath(pkg string) string {
 	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".etag")
 }
 
+func (h *npmHandler) metadataExpiryPath(pkg string) string {
+	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".expiry")
+}
+
 func (h *npmHandler) tarballCachePath(pkg, filename string) string {
 	if !h.artifactCacheEnabled() {
 		return ""
@@ -304,10 +309,15 @@ func (h *npmHandler) readMetadataCache(pkg string) (metadataCacheEntry, bool) {
 		return metadataCacheEntry{}, false
 	}
 	etagBytes, _ := os.ReadFile(h.metadataETagPath(pkg))
+	expiresAt := info.ModTime().Add(h.cfg.Protocols.NPM.MetadataTTL)
+	if cachedExpiry, ok := h.readMetadataExpiry(pkg); ok {
+		expiresAt = cachedExpiry
+	}
 	return metadataCacheEntry{
-		Body:  body,
-		ETag:  string(etagBytes),
-		Fresh: time.Since(info.ModTime()) <= h.cfg.Protocols.NPM.MetadataTTL,
+		Body:      body,
+		ETag:      string(etagBytes),
+		ExpiresAt: expiresAt,
+		Fresh:     time.Now().Before(expiresAt),
 	}, true
 }
 
@@ -333,7 +343,27 @@ func (h *npmHandler) writeMetadataCache(pkg string, body []byte, etag string) (b
 	} else {
 		_ = os.Remove(etagPath)
 	}
+	if err := h.writeMetadataExpiry(pkg, time.Now().Add(h.cfg.Protocols.NPM.MetadataTTL)); err != nil {
+		h.logger.Error("failed to write npm metadata expiry file; serving uncached body", "path", h.metadataExpiryPath(pkg), "error", err)
+		return false, err
+	}
 	return true, nil
+}
+
+func (h *npmHandler) readMetadataExpiry(pkg string) (time.Time, bool) {
+	b, err := os.ReadFile(h.metadataExpiryPath(pkg))
+	if err != nil {
+		return time.Time{}, false
+	}
+	ns, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(b)))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return ns, true
+}
+
+func (h *npmHandler) writeMetadataExpiry(pkg string, expiresAt time.Time) error {
+	return os.WriteFile(h.metadataExpiryPath(pkg), []byte(expiresAt.UTC().Format(time.RFC3339Nano)), 0o644)
 }
 
 func (h *npmHandler) revalidateMetadataCache(r *http.Request, pkg string, entry metadataCacheEntry) (metadataCacheEntry, int, error) {
@@ -353,16 +383,11 @@ func (h *npmHandler) revalidateMetadataCache(r *http.Request, pkg string, entry 
 		return metadataCacheEntry{}, 0, err
 	}
 	if resp.StatusCode == http.StatusNotModified {
-		path := h.metadataCachePath(pkg)
-		now := time.Now()
-		if err := os.Chtimes(path, now, now); err != nil {
+		refreshedExpiry := time.Now().Add(h.cfg.Protocols.NPM.MetadataTTL)
+		if err := h.writeMetadataExpiry(pkg, refreshedExpiry); err != nil {
 			return metadataCacheEntry{}, 0, err
 		}
-		etagPath := h.metadataETagPath(pkg)
-		if _, err := os.Stat(etagPath); err == nil {
-			_ = os.Chtimes(etagPath, now, now)
-		}
-		return metadataCacheEntry{Body: entry.Body, ETag: entry.ETag, Fresh: true}, http.StatusNotModified, nil
+		return metadataCacheEntry{Body: entry.Body, ETag: entry.ETag, ExpiresAt: refreshedExpiry, Fresh: true}, http.StatusNotModified, nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		return metadataCacheEntry{Body: body}, resp.StatusCode, nil
@@ -371,7 +396,7 @@ func (h *npmHandler) revalidateMetadataCache(r *http.Request, pkg string, entry 
 	if err != nil {
 		return metadataCacheEntry{}, 0, err
 	}
-	return metadataCacheEntry{Body: body, ETag: resp.Header.Get("ETag"), Fresh: true}, http.StatusOK, nil
+	return metadataCacheEntry{Body: body, ETag: resp.Header.Get("ETag"), ExpiresAt: time.Now().Add(h.cfg.Protocols.NPM.MetadataTTL), Fresh: true}, http.StatusOK, nil
 }
 
 func rewriteNPMMetadataTarballs(body []byte, baseURL, packageName string) ([]byte, error) {

--- a/npm.go
+++ b/npm.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -18,6 +17,8 @@ type npmHandler struct {
 	logger         *slog.Logger
 	httpClient     *http.Client
 	authenticators map[string]Authenticator
+	npmCache       npmCacheStore
+	now            func() time.Time
 }
 
 type metadataCacheEntry struct {
@@ -27,17 +28,23 @@ type metadataCacheEntry struct {
 	Fresh     bool
 }
 
-func newNPMHandler(cfg *Config, logger *slog.Logger, authenticators map[string]Authenticator) http.Handler {
+func newNPMHandler(cfg *Config, logger *slog.Logger, authenticators map[string]Authenticator) (http.Handler, error) {
 	timeout := cfg.Server.FetchTimeout
 	if timeout == 0 {
 		timeout = 30 * time.Second
+	}
+	cacheStore, err := newNPMCacheStore(cfg)
+	if err != nil {
+		return nil, err
 	}
 	return &npmHandler{
 		cfg:            cfg,
 		logger:         logger.With("component", "npm"),
 		httpClient:     &http.Client{Timeout: timeout},
 		authenticators: authenticators,
-	}
+		npmCache:       cacheStore,
+		now:            time.Now,
+	}, nil
 }
 
 func (h *npmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -198,9 +205,9 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		}
 		gitlabToken := ""
 		_, gitlabToken, _ = authorizeRequestToken(r, rule.AuthModule)
-		cachePath := h.rewriteTarballCachePath(rule, pkg, filename)
-		if cachePath != "" {
-			if body, err := os.ReadFile(cachePath); err == nil {
+		cacheKey := h.rewriteTarballCacheKey(rule, pkg, filename)
+		if cacheKey != "" {
+			if body, _, ok := h.readCacheBytes(cacheKey); ok {
 				recordProtocolCacheHit("npm", "artifact")
 				w.Header().Set("Content-Type", "application/octet-stream")
 				finalSize = len(body)
@@ -214,17 +221,9 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), statusCode)
 			return
 		}
-		if cachePath != "" {
-			if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
-				h.logger.Error("failed to create npm cache directory; serving uncached body", "path", filepath.Dir(cachePath), "error", err)
-				recordProtocolCacheError("npm", "artifact")
-				w.Header().Set("Content-Type", "application/octet-stream")
-				finalSize = len(body)
-				_, _ = w.Write(body)
-				return
-			}
-			if err := os.WriteFile(cachePath, body, 0o644); err != nil {
-				h.logger.Error("failed to write npm cache file; serving uncached body", "path", cachePath, "error", err)
+		if cacheKey != "" {
+			if err := h.writeCacheBytes(cacheKey, body); err != nil {
+				h.logger.Error("failed to write npm cache body; serving uncached body", "key", cacheKey, "error", err)
 				recordProtocolCacheError("npm", "artifact")
 				w.Header().Set("Content-Type", "application/octet-stream")
 				finalSize = len(body)
@@ -245,9 +244,9 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	cachePath := h.tarballCachePath(pkg, filename)
-	if cachePath != "" {
-		if body, err := os.ReadFile(cachePath); err == nil {
+	cacheKey := h.tarballCacheKey(pkg, filename)
+	if cacheKey != "" {
+		if body, _, ok := h.readCacheBytes(cacheKey); ok {
 			recordProtocolCacheHit("npm", "artifact")
 			w.Header().Set("Content-Type", "application/octet-stream")
 			finalSize = len(body)
@@ -270,17 +269,9 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(body)
 		return
 	}
-	if cachePath != "" {
-		if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
-			h.logger.Error("failed to create npm cache directory; serving uncached body", "path", filepath.Dir(cachePath), "error", err)
-			recordProtocolCacheError("npm", "artifact")
-			w.Header().Set("Content-Type", "application/octet-stream")
-			finalSize = len(body)
-			_, _ = w.Write(body)
-			return
-		}
-		if err := os.WriteFile(cachePath, body, 0o644); err != nil {
-			h.logger.Error("failed to write npm cache file; serving uncached body", "path", cachePath, "error", err)
+	if cacheKey != "" {
+		if err := h.writeCacheBytes(cacheKey, body); err != nil {
+			h.logger.Error("failed to write npm cache body; serving uncached body", "key", cacheKey, "error", err)
 			recordProtocolCacheError("npm", "artifact")
 			w.Header().Set("Content-Type", "application/octet-stream")
 			finalSize = len(body)
@@ -348,57 +339,97 @@ func parseNPMTarballPath(path string) (string, string) {
 }
 
 func (h *npmHandler) metadataCacheEnabled() bool {
-	return h.cfg.Cache.Enabled && h.cfg.Cache.Type == "disk" && h.cfg.Cache.Disk.Path != "" && h.cfg.Protocols.NPM.MetadataTTL > 0
+	return h.npmCache != nil && h.cfg.Protocols.NPM.MetadataTTL > 0
 }
 
 func (h *npmHandler) artifactCacheEnabled() bool {
-	return h.cfg.Cache.Enabled && h.cfg.Cache.Type == "disk" && h.cfg.Cache.Disk.Path != ""
+	return h.npmCache != nil
 }
 
 func (h *npmHandler) metadataCachePath(pkg string) string {
-	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".json")
+	return filepath.Join(h.cfg.Cache.Disk.Path, h.metadataCacheKey(pkg))
 }
 
 func (h *npmHandler) metadataETagPath(pkg string) string {
-	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".etag")
+	return filepath.Join(h.cfg.Cache.Disk.Path, h.metadataETagKey(pkg))
 }
 
 func (h *npmHandler) metadataExpiryPath(pkg string) string {
-	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-meta", npmCachePackageKey(pkg)+".expiry")
+	return filepath.Join(h.cfg.Cache.Disk.Path, h.metadataExpiryKey(pkg))
+}
+
+func (h *npmHandler) metadataCacheKey(pkg string) string {
+	return filepath.ToSlash(filepath.Join("npm-meta", npmCachePackageKey(pkg)+".json"))
+}
+
+func (h *npmHandler) metadataETagKey(pkg string) string {
+	return filepath.ToSlash(filepath.Join("npm-meta", npmCachePackageKey(pkg)+".etag"))
+}
+
+func (h *npmHandler) metadataExpiryKey(pkg string) string {
+	return filepath.ToSlash(filepath.Join("npm-meta", npmCachePackageKey(pkg)+".expiry"))
 }
 
 func (h *npmHandler) tarballCachePath(pkg, filename string) string {
+	return filepath.Join(h.cfg.Cache.Disk.Path, h.tarballCacheKey(pkg, filename))
+}
+
+func (h *npmHandler) tarballCacheKey(pkg, filename string) string {
 	if !h.artifactCacheEnabled() {
 		return ""
 	}
-	return filepath.Join(h.cfg.Cache.Disk.Path, "npm", npmCachePackageKey(pkg), filename)
+	return filepath.ToSlash(filepath.Join("npm", npmCachePackageKey(pkg), filename))
 }
 
 func (h *npmHandler) rewriteTarballCachePath(rule NPMRewriteRule, pkg, filename string) string {
+	return filepath.Join(h.cfg.Cache.Disk.Path, h.rewriteTarballCacheKey(rule, pkg, filename))
+}
+
+func (h *npmHandler) rewriteTarballCacheKey(rule NPMRewriteRule, pkg, filename string) string {
 	if !h.artifactCacheEnabled() {
 		return ""
 	}
 	hostKey := strings.TrimSpace(rule.TargetHost)
 	hostKey = strings.ReplaceAll(hostKey, ":", "_")
 	groupKey := strings.ReplaceAll(normalizeTargetGroup(rule.TargetGroup), "/", "__")
-	return filepath.Join(h.cfg.Cache.Disk.Path, "npm-rewrite", hostKey, groupKey, npmCachePackageKey(pkg), filename)
+	return filepath.ToSlash(filepath.Join("npm-rewrite", hostKey, groupKey, npmCachePackageKey(pkg), filename))
+}
+
+func (h *npmHandler) readCacheBytes(key string) ([]byte, time.Time, bool) {
+	if h.npmCache == nil || key == "" {
+		return nil, time.Time{}, false
+	}
+	body, modifiedAt, err := h.npmCache.Get(key)
+	if err != nil {
+		return nil, time.Time{}, false
+	}
+	return body, modifiedAt, true
+}
+
+func (h *npmHandler) writeCacheBytes(key string, body []byte) error {
+	if h.npmCache == nil || key == "" {
+		return nil
+	}
+	return h.npmCache.Put(key, body)
+}
+
+func (h *npmHandler) deleteCacheKey(key string) error {
+	if h.npmCache == nil || key == "" {
+		return nil
+	}
+	return h.npmCache.Delete(key)
 }
 
 func (h *npmHandler) readMetadataCache(pkg string) (metadataCacheEntry, bool) {
 	if !h.metadataCacheEnabled() {
 		return metadataCacheEntry{}, false
 	}
-	path := h.metadataCachePath(pkg)
-	info, err := os.Stat(path)
-	if err != nil {
+	body, modifiedAt, ok := h.readCacheBytes(h.metadataCacheKey(pkg))
+	if !ok {
 		return metadataCacheEntry{}, false
 	}
-	body, err := os.ReadFile(path)
-	if err != nil {
-		return metadataCacheEntry{}, false
-	}
-	etagBytes, _ := os.ReadFile(h.metadataETagPath(pkg))
-	expiresAt := info.ModTime().Add(h.cfg.Protocols.NPM.MetadataTTL)
+	etagBytes, _, _ := h.readCacheBytes(h.metadataETagKey(pkg))
+	expiresAt := modifiedAt.Add(h.cfg.Protocols.NPM.MetadataTTL)
 	if cachedExpiry, ok := h.readMetadataExpiry(pkg); ok {
 		expiresAt = cachedExpiry
 	}
@@ -406,7 +437,7 @@ func (h *npmHandler) readMetadataCache(pkg string) (metadataCacheEntry, bool) {
 		Body:      body,
 		ETag:      string(etagBytes),
 		ExpiresAt: expiresAt,
-		Fresh:     time.Now().Before(expiresAt),
+		Fresh:     h.now().Before(expiresAt),
 	}, true
 }
 
@@ -414,34 +445,29 @@ func (h *npmHandler) writeMetadataCache(pkg string, body []byte, etag string) (b
 	if !h.metadataCacheEnabled() {
 		return false, nil
 	}
-	path := h.metadataCachePath(pkg)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		h.logger.Error("failed to create npm metadata cache directory; serving uncached body", "path", filepath.Dir(path), "error", err)
+	if err := h.writeCacheBytes(h.metadataCacheKey(pkg), body); err != nil {
+		h.logger.Error("failed to write npm metadata cache body; serving uncached body", "key", h.metadataCacheKey(pkg), "error", err)
 		return false, err
 	}
-	if err := os.WriteFile(path, body, 0o644); err != nil {
-		h.logger.Error("failed to write npm metadata cache file; serving uncached body", "path", path, "error", err)
-		return false, err
-	}
-	etagPath := h.metadataETagPath(pkg)
 	if etag != "" {
-		if err := os.WriteFile(etagPath, []byte(etag), 0o644); err != nil {
-			h.logger.Error("failed to write npm metadata etag file; serving uncached body", "path", etagPath, "error", err)
+		if err := h.writeCacheBytes(h.metadataETagKey(pkg), []byte(etag)); err != nil {
+			h.logger.Error("failed to write npm metadata etag cache body; serving uncached body", "key", h.metadataETagKey(pkg), "error", err)
 			return false, err
 		}
-	} else {
-		_ = os.Remove(etagPath)
+	} else if err := h.deleteCacheKey(h.metadataETagKey(pkg)); err != nil {
+		h.logger.Error("failed to delete npm metadata etag cache body; serving uncached body", "key", h.metadataETagKey(pkg), "error", err)
+		return false, err
 	}
-	if err := h.writeMetadataExpiry(pkg, time.Now().Add(h.cfg.Protocols.NPM.MetadataTTL)); err != nil {
-		h.logger.Error("failed to write npm metadata expiry file; serving uncached body", "path", h.metadataExpiryPath(pkg), "error", err)
+	if err := h.writeMetadataExpiry(pkg, h.now().Add(h.cfg.Protocols.NPM.MetadataTTL)); err != nil {
+		h.logger.Error("failed to write npm metadata expiry cache body; serving uncached body", "key", h.metadataExpiryKey(pkg), "error", err)
 		return false, err
 	}
 	return true, nil
 }
 
 func (h *npmHandler) readMetadataExpiry(pkg string) (time.Time, bool) {
-	b, err := os.ReadFile(h.metadataExpiryPath(pkg))
-	if err != nil {
+	b, _, ok := h.readCacheBytes(h.metadataExpiryKey(pkg))
+	if !ok {
 		return time.Time{}, false
 	}
 	ns, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(b)))
@@ -452,7 +478,7 @@ func (h *npmHandler) readMetadataExpiry(pkg string) (time.Time, bool) {
 }
 
 func (h *npmHandler) writeMetadataExpiry(pkg string, expiresAt time.Time) error {
-	return os.WriteFile(h.metadataExpiryPath(pkg), []byte(expiresAt.UTC().Format(time.RFC3339Nano)), 0o644)
+	return h.writeCacheBytes(h.metadataExpiryKey(pkg), []byte(expiresAt.UTC().Format(time.RFC3339Nano)))
 }
 
 func (h *npmHandler) revalidateMetadataCache(r *http.Request, pkg string, entry metadataCacheEntry) (metadataCacheEntry, int, error) {
@@ -472,7 +498,7 @@ func (h *npmHandler) revalidateMetadataCache(r *http.Request, pkg string, entry 
 		return metadataCacheEntry{}, 0, err
 	}
 	if resp.StatusCode == http.StatusNotModified {
-		refreshedExpiry := time.Now().Add(h.cfg.Protocols.NPM.MetadataTTL)
+		refreshedExpiry := h.now().Add(h.cfg.Protocols.NPM.MetadataTTL)
 		if err := h.writeMetadataExpiry(pkg, refreshedExpiry); err != nil {
 			return metadataCacheEntry{}, 0, err
 		}
@@ -485,7 +511,7 @@ func (h *npmHandler) revalidateMetadataCache(r *http.Request, pkg string, entry 
 	if err != nil {
 		return metadataCacheEntry{}, 0, err
 	}
-	return metadataCacheEntry{Body: body, ETag: resp.Header.Get("ETag"), ExpiresAt: time.Now().Add(h.cfg.Protocols.NPM.MetadataTTL), Fresh: true}, http.StatusOK, nil
+	return metadataCacheEntry{Body: body, ETag: resp.Header.Get("ETag"), ExpiresAt: h.now().Add(h.cfg.Protocols.NPM.MetadataTTL), Fresh: true}, http.StatusOK, nil
 }
 
 func rewriteNPMMetadataTarballs(body []byte, baseURL, packageName string) ([]byte, error) {

--- a/npm.go
+++ b/npm.go
@@ -65,11 +65,22 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("Received request", "protocol", "npm", "kind", "metadata", "method", r.Method, "path", r.URL.Path, "package", pkg)
 
 	if rule, ok := matchNPMRewriteRule(h.cfg.Protocols.NPM.RewriteRules, pkg); ok {
-		if _, err := repoPathForPackage(rule, pkg); err != nil {
+		repoPath, err := repoPathForPackage(rule, pkg)
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		http.Error(w, "npm rewrite rules are recognized but not implemented yet", http.StatusNotImplemented)
+		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg, Scope: rule.Scope, RepoPath: repoPath}) {
+			return
+		}
+		body, statusCode, err := h.synthesizeRewrittenMetadata(r, pkg, rule)
+		if err != nil {
+			http.Error(w, err.Error(), statusCode)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		finalSize = len(body)
+		_, _ = w.Write(body)
 		return
 	}
 
@@ -177,11 +188,15 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 	h.logger.Info("Received request", "protocol", "npm", "kind", "artifact", "method", r.Method, "path", r.URL.Path, "package", pkg, "filename", filename)
 
 	if rule, ok := matchNPMRewriteRule(h.cfg.Protocols.NPM.RewriteRules, pkg); ok {
-		if _, err := repoPathForPackage(rule, pkg); err != nil {
+		repoPath, err := repoPathForPackage(rule, pkg)
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		http.Error(w, "npm rewrite rules are recognized but not implemented yet", http.StatusNotImplemented)
+		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg, Scope: rule.Scope, RepoPath: repoPath}) {
+			return
+		}
+		http.Error(w, "npm rewrite tarballs are not implemented yet", http.StatusNotImplemented)
 		return
 	}
 
@@ -241,9 +256,16 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *npmHandler) doUpstreamGet(r *http.Request, upstreamURL string) (*http.Response, []byte, error) {
+	return h.doAuthorizedUpstreamGet(r, upstreamURL, "")
+}
+
+func (h *npmHandler) doAuthorizedUpstreamGet(r *http.Request, upstreamURL, bearerToken string) (*http.Response, []byte, error) {
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstreamURL, nil)
 	if err != nil {
 		return nil, nil, err
+	}
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
 	}
 	resp, err := h.httpClient.Do(req)
 	if err != nil {

--- a/npm.go
+++ b/npm.go
@@ -14,20 +14,22 @@ import (
 )
 
 type npmHandler struct {
-	cfg        *Config
-	logger     *slog.Logger
-	httpClient *http.Client
+	cfg            *Config
+	logger         *slog.Logger
+	httpClient     *http.Client
+	authenticators map[string]Authenticator
 }
 
-func newNPMHandler(cfg *Config, logger *slog.Logger) http.Handler {
+func newNPMHandler(cfg *Config, logger *slog.Logger, authenticators map[string]Authenticator) http.Handler {
 	timeout := cfg.Server.FetchTimeout
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}
 	return &npmHandler{
-		cfg:        cfg,
-		logger:     logger.With("component", "npm"),
-		httpClient: &http.Client{Timeout: timeout},
+		cfg:            cfg,
+		logger:         logger.With("component", "npm"),
+		httpClient:     &http.Client{Timeout: timeout},
+		authenticators: authenticators,
 	}
 }
 
@@ -48,6 +50,12 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	if pkg == "" {
 		http.Error(w, "invalid package path", http.StatusBadRequest)
 		return
+	}
+
+	if rule, ok := matchProtectedScope(h.cfg.Protocols.NPM.ProtectedScopes, pkg); ok {
+		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg}) {
+			return
+		}
 	}
 
 	if body, ok := h.readFreshMetadataCache(pkg); ok {
@@ -89,6 +97,12 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid tarball path", http.StatusBadRequest)
 		return
 	}
+	if rule, ok := matchProtectedScope(h.cfg.Protocols.NPM.ProtectedScopes, pkg); ok {
+		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg}) {
+			return
+		}
+	}
+
 	cachePath := filepath.Join(h.cfg.Cache.Disk.Path, "npm", npmCachePackageKey(pkg), filename)
 	if body, err := os.ReadFile(cachePath); err == nil {
 		w.Header().Set("Content-Type", "application/octet-stream")

--- a/npm.go
+++ b/npm.go
@@ -64,6 +64,15 @@ func (h *npmHandler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	h.logger.Info("Received request", "protocol", "npm", "kind", "metadata", "method", r.Method, "path", r.URL.Path, "package", pkg)
 
+	if rule, ok := matchNPMRewriteRule(h.cfg.Protocols.NPM.RewriteRules, pkg); ok {
+		if _, err := repoPathForPackage(rule, pkg); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "npm rewrite rules are recognized but not implemented yet", http.StatusNotImplemented)
+		return
+	}
+
 	if rule, ok := matchProtectedScope(h.cfg.Protocols.NPM.ProtectedScopes, pkg); ok {
 		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg, Scope: rule.Scope}) {
 			return
@@ -166,6 +175,15 @@ func (h *npmHandler) handleTarball(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.logger.Info("Received request", "protocol", "npm", "kind", "artifact", "method", r.Method, "path", r.URL.Path, "package", pkg, "filename", filename)
+
+	if rule, ok := matchNPMRewriteRule(h.cfg.Protocols.NPM.RewriteRules, pkg); ok {
+		if _, err := repoPathForPackage(rule, pkg); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "npm rewrite rules are recognized but not implemented yet", http.StatusNotImplemented)
+		return
+	}
 
 	if rule, ok := matchProtectedScope(h.cfg.Protocols.NPM.ProtectedScopes, pkg); ok {
 		if !authorizeRequest(w, r, h.authenticators, rule.AuthModule, AuthRequest{Protocol: "npm", Path: r.URL.Path, Resource: pkg, Scope: rule.Scope}) {

--- a/npm_cache_test.go
+++ b/npm_cache_test.go
@@ -12,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/VictoriaMetrics/metrics"
 )
 
 type fakeNPMCacheStore struct {
@@ -19,6 +21,10 @@ type fakeNPMCacheStore struct {
 	bodies  map[string][]byte
 	modTime map[string]time.Time
 	now     func() time.Time
+}
+
+type failingNPMCacheStore struct {
+	err error
 }
 
 func newFakeNPMCacheStore() *fakeNPMCacheStore {
@@ -54,6 +60,18 @@ func (s *fakeNPMCacheStore) Delete(key string) error {
 	delete(s.bodies, key)
 	delete(s.modTime, key)
 	return nil
+}
+
+func (s *failingNPMCacheStore) Get(string) ([]byte, time.Time, error) {
+	return nil, time.Time{}, s.err
+}
+
+func (s *failingNPMCacheStore) Put(string, []byte) error {
+	return s.err
+}
+
+func (s *failingNPMCacheStore) Delete(string) error {
+	return s.err
 }
 
 func newTestNPMHandler(t *testing.T, upstream string, store npmCacheStore) *npmHandler {
@@ -135,6 +153,43 @@ func TestNewNPMHandlerUsesS3CacheStoreWhenConfigured(t *testing.T) {
 	h := handler.(*npmHandler)
 	if _, ok := h.npmCache.(*s3NPMCacheStore); !ok {
 		t.Fatalf("npm cache store = %T, want *s3NPMCacheStore", h.npmCache)
+	}
+}
+
+func TestNPMMetadataCacheReadErrorsRecordCacheError(t *testing.T) {
+	before := metrics.GetOrCreateCounter(`toru_cache_errors_by_protocol_total{protocol="npm",class="metadata"}`).Get()
+	h := newTestNPMHandler(t, "https://registry.npmjs.org", &failingNPMCacheStore{err: fmt.Errorf("boom")})
+	if _, ok := h.readMetadataCache("toru-fixture-pkg"); ok {
+		t.Fatalf("readMetadataCache ok=true, want false on cache read error")
+	}
+	after := metrics.GetOrCreateCounter(`toru_cache_errors_by_protocol_total{protocol="npm",class="metadata"}`).Get()
+	if after != before+1 {
+		t.Fatalf("metadata cache error counter delta = %v, want 1", after-before)
+	}
+}
+
+func TestNPMArtifactCacheReadErrorsRecordCacheError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pkg/-/pkg-1.0.0.tgz" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("tarball-body"))
+	}))
+	defer upstream.Close()
+
+	before := metrics.GetOrCreateCounter(`toru_cache_errors_by_protocol_total{protocol="npm",class="artifact"}`).Get()
+	h := newTestNPMHandler(t, upstream.URL, &failingNPMCacheStore{err: fmt.Errorf("boom")})
+	req := httptest.NewRequest(http.MethodGet, "http://toru.test/pkg/-/pkg-1.0.0.tgz", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200", rr.Code, rr.Body.String())
+	}
+	after := metrics.GetOrCreateCounter(`toru_cache_errors_by_protocol_total{protocol="npm",class="artifact"}`).Get()
+	if after < before+1 {
+		t.Fatalf("artifact cache error counter delta = %v, want at least 1", after-before)
 	}
 }
 

--- a/npm_cache_test.go
+++ b/npm_cache_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeNPMCacheStore struct {
+	mu      sync.Mutex
+	bodies  map[string][]byte
+	modTime map[string]time.Time
+	now     func() time.Time
+}
+
+func newFakeNPMCacheStore() *fakeNPMCacheStore {
+	return &fakeNPMCacheStore{
+		bodies:  map[string][]byte{},
+		modTime: map[string]time.Time{},
+		now:     time.Now,
+	}
+}
+
+func (s *fakeNPMCacheStore) Get(key string) ([]byte, time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	body, ok := s.bodies[key]
+	if !ok {
+		return nil, time.Time{}, fs.ErrNotExist
+	}
+	copyBody := append([]byte(nil), body...)
+	return copyBody, s.modTime[key], nil
+}
+
+func (s *fakeNPMCacheStore) Put(key string, body []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bodies[key] = append([]byte(nil), body...)
+	s.modTime[key] = s.now()
+	return nil
+}
+
+func (s *fakeNPMCacheStore) Delete(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.bodies, key)
+	delete(s.modTime, key)
+	return nil
+}
+
+func newTestNPMHandler(t *testing.T, upstream string, store npmCacheStore) *npmHandler {
+	t.Helper()
+	cfg := &Config{}
+	cfg.Server.FetchTimeout = 5 * time.Second
+	cfg.Cache.Enabled = true
+	cfg.Cache.Type = "s3"
+	cfg.Protocols.NPM.Enabled = true
+	cfg.Protocols.NPM.Upstream = upstream
+	cfg.Protocols.NPM.BaseURL = "http://example.com"
+	cfg.Protocols.NPM.MetadataTTL = time.Hour
+	return &npmHandler{
+		cfg:            cfg,
+		logger:         slog.Default(),
+		httpClient:     &http.Client{Timeout: 5 * time.Second},
+		authenticators: map[string]Authenticator{},
+		npmCache:       store,
+		now:            time.Now,
+	}
+}
+
+func TestNewNPMHandlerUsesDiskCacheStoreCompatibility(t *testing.T) {
+	cacheRoot := t.TempDir()
+	cfg := &Config{}
+	cfg.Server.FetchTimeout = 5 * time.Second
+	cfg.Cache.Enabled = true
+	cfg.Cache.Type = "disk"
+	cfg.Cache.Disk.Path = cacheRoot
+	cfg.Protocols.NPM.Enabled = true
+	cfg.Protocols.NPM.Upstream = "https://registry.npmjs.org"
+	cfg.Protocols.NPM.BaseURL = "http://example.com"
+	cfg.Protocols.NPM.MetadataTTL = time.Hour
+
+	handler, err := newNPMHandler(cfg, slog.Default(), map[string]Authenticator{})
+	if err != nil {
+		t.Fatalf("newNPMHandler: %v", err)
+	}
+	h := handler.(*npmHandler)
+	if _, ok := h.npmCache.(*diskNPMCacheStore); !ok {
+		t.Fatalf("npm cache store = %T, want *diskNPMCacheStore", h.npmCache)
+	}
+	wrote, err := h.writeMetadataCache("toru-fixture-pkg", []byte(`{"name":"toru-fixture-pkg"}`), `"etag-1"`)
+	if err != nil {
+		t.Fatalf("writeMetadataCache: %v", err)
+	}
+	if !wrote {
+		t.Fatalf("writeMetadataCache wrote=false, want true")
+	}
+	for _, path := range []string{
+		filepath.Join(cacheRoot, "npm-meta", "toru-fixture-pkg.json"),
+		filepath.Join(cacheRoot, "npm-meta", "toru-fixture-pkg.etag"),
+		filepath.Join(cacheRoot, "npm-meta", "toru-fixture-pkg.expiry"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected legacy disk cache path %q: %v", path, err)
+		}
+	}
+}
+
+func TestNewNPMHandlerUsesS3CacheStoreWhenConfigured(t *testing.T) {
+	cfg := &Config{}
+	cfg.Server.FetchTimeout = 5 * time.Second
+	cfg.Cache.Enabled = true
+	cfg.Cache.Type = "s3"
+	cfg.Cache.S3.Region = "us-east-1"
+	cfg.Cache.S3.Bucket = "toru-test"
+	cfg.Cache.S3.AccessKey = "test"
+	cfg.Cache.S3.SecretKey = "test"
+	cfg.Protocols.NPM.Enabled = true
+	cfg.Protocols.NPM.Upstream = "https://registry.npmjs.org"
+	cfg.Protocols.NPM.BaseURL = "http://example.com"
+	cfg.Protocols.NPM.MetadataTTL = time.Hour
+
+	handler, err := newNPMHandler(cfg, slog.Default(), map[string]Authenticator{})
+	if err != nil {
+		t.Fatalf("newNPMHandler: %v", err)
+	}
+	h := handler.(*npmHandler)
+	if _, ok := h.npmCache.(*s3NPMCacheStore); !ok {
+		t.Fatalf("npm cache store = %T, want *s3NPMCacheStore", h.npmCache)
+	}
+}
+
+func TestNPMMetadataCacheSupportsS3Store(t *testing.T) {
+	store := newFakeNPMCacheStore()
+	h := newTestNPMHandler(t, "https://registry.npmjs.org", store)
+
+	wrote, err := h.writeMetadataCache("toru-fixture-pkg", []byte(`{"name":"toru-fixture-pkg"}`), `"etag-1"`)
+	if err != nil {
+		t.Fatalf("writeMetadataCache: %v", err)
+	}
+	if !wrote {
+		t.Fatalf("writeMetadataCache wrote=false, want true")
+	}
+	entry, ok := h.readMetadataCache("toru-fixture-pkg")
+	if !ok {
+		t.Fatalf("readMetadataCache ok=false, want true")
+	}
+	if string(entry.Body) != `{"name":"toru-fixture-pkg"}` {
+		t.Fatalf("entry body = %q", string(entry.Body))
+	}
+	if entry.ETag != `"etag-1"` {
+		t.Fatalf("entry etag = %q, want %q", entry.ETag, `"etag-1"`)
+	}
+	if !entry.Fresh {
+		t.Fatalf("entry should be fresh")
+	}
+}
+
+func TestNPMTarballCacheUsesS3Store(t *testing.T) {
+	var tarballHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pkg/-/pkg-1.0.0.tgz" {
+			http.NotFound(w, r)
+			return
+		}
+		tarballHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("tarball-body"))
+	}))
+	defer upstream.Close()
+
+	h := newTestNPMHandler(t, upstream.URL, newFakeNPMCacheStore())
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "http://toru.test/pkg/-/pkg-1.0.0.tgz", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d status=%d body=%q, want 200", i+1, rr.Code, rr.Body.String())
+		}
+		if rr.Body.String() != "tarball-body" {
+			t.Fatalf("request %d body=%q, want tarball-body", i+1, rr.Body.String())
+		}
+	}
+	if hits := tarballHits.Load(); hits != 1 {
+		t.Fatalf("upstream tarball hits=%d, want 1", hits)
+	}
+}
+
+func TestNPMRewriteTarballCacheUsesS3Store(t *testing.T) {
+	archiveHits := &atomic.Int32{}
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags:        []string{"v1.0.0"},
+			ArchiveHits: archiveHits,
+			Archives: map[string]map[string]string{
+				"v1.0.0": {
+					"package.json": `{"name":"@example-commons/foo","version":"1.0.0"}`,
+					"index.js":     `module.exports = 42`,
+				},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	h := newTestNPMHandler(t, "https://registry.npmjs.org", newFakeNPMCacheStore())
+	h.cfg.Protocols.NPM.RewriteRules = []NPMRewriteRule{{
+		Scope:       "@example-commons",
+		TargetHost:  gitlab.Host(),
+		TargetGroup: "commons",
+		AuthModule:  "static",
+	}}
+	h.authenticators["static"] = &StaticTokenAuthenticator{Token: "secret"}
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://toru.test/%%40example-commons%%2Ffoo/-/foo-1.0.0.tgz"), nil)
+		req.SetBasicAuth("static", "secret")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d status=%d body=%q, want 200", i+1, rr.Code, rr.Body.String())
+		}
+	}
+	if hits := archiveHits.Load(); hits != 1 {
+		t.Fatalf("gitlab archive hits=%d, want 1", hits)
+	}
+}

--- a/npm_e2e_test.go
+++ b/npm_e2e_test.go
@@ -154,6 +154,177 @@ base_url = "http://127.0.0.1:%d"
 	}
 }
 
+func TestNPMMetadataStaleRevalidatesWithETag304(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var metadataHits atomic.Int32
+	upstream := newFakeNPMRegistryWithOptions(t, fakeNPMRegistryOptions{
+		UnscopedMetadataHits: &metadataHits,
+		MetadataETag:         `"toru-fixture-etag"`,
+		Metadata304OnMatch:   true,
+	})
+
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "1ms"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, cacheRoot, upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort)
+	resp1, body1, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first metadata request: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first metadata status=%d body=%q, want 200", resp1.StatusCode, body1)
+	}
+	if hits := metadataHits.Load(); hits != 1 {
+		t.Fatalf("upstream metadata hits after first request = %d, want 1", hits)
+	}
+
+	etagBytes, err := os.ReadFile(filepath.Join(cacheRoot, "npm-meta", "toru-fixture-pkg.etag"))
+	if err != nil {
+		t.Fatalf("read etag sidecar: %v", err)
+	}
+	if string(etagBytes) != `"toru-fixture-etag"` {
+		t.Fatalf("etag sidecar = %q, want %q", string(etagBytes), `"toru-fixture-etag"`)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	resp2, body2, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second metadata request: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second metadata status=%d body=%q, want 200", resp2.StatusCode, body2)
+	}
+	if hits := metadataHits.Load(); hits != 2 {
+		t.Fatalf("upstream metadata hits after 304 revalidation = %d, want 2", hits)
+	}
+
+	resp3, body3, err := getURL(url)
+	if err != nil {
+		t.Fatalf("third metadata request: %v", err)
+	}
+	resp3.Body.Close()
+	if resp3.StatusCode != http.StatusOK {
+		t.Fatalf("third metadata status=%d body=%q, want 200", resp3.StatusCode, body3)
+	}
+	if hits := metadataHits.Load(); hits != 2 {
+		t.Fatalf("upstream metadata hits after immediate post-304 cache hit = %d, want still 2", hits)
+	}
+}
+
+func TestNPMMetadataStaleRevalidationPropagatesUpstreamErrorsWithoutRefetch(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var metadataHits atomic.Int32
+	upstream := newFakeNPMRegistryWithOptions(t, fakeNPMRegistryOptions{
+		UnscopedMetadataHits:  &metadataHits,
+		MetadataETag:          `"toru-fixture-etag"`,
+		MetadataStatusOnMatch: http.StatusNotFound,
+	})
+
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "1ms"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, cacheRoot, upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort)
+	resp1, body1, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first metadata request: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first metadata status=%d body=%q, want 200", resp1.StatusCode, body1)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	resp2, body2, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second metadata request: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusNotFound {
+		t.Fatalf("second metadata status=%d body=%q, want 404", resp2.StatusCode, body2)
+	}
+	if hits := metadataHits.Load(); hits != 2 {
+		t.Fatalf("upstream metadata hits after stale error revalidation = %d, want 2", hits)
+	}
+}
+
 func TestNPMMetadataCacheDisabledByCacheConfig(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)

--- a/npm_e2e_test.go
+++ b/npm_e2e_test.go
@@ -273,6 +273,241 @@ base_url = "http://127.0.0.1:%d"
 	}
 }
 
+func TestNPMProtectedScopeRequiresAuth(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "0"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.protected_scopes]]
+scope = "@toru"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/%%40toru%%2Ffixture-scoped", npmPort)
+	resp1, _, err := getURL(url)
+	if err != nil {
+		t.Fatalf("unauthenticated protected metadata request: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated protected metadata status=%d, want 401", resp1.StatusCode)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.SetBasicAuth("static", "secret")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("authenticated protected metadata request: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated protected metadata status=%d, want 200", resp2.StatusCode)
+	}
+}
+
+func TestNPMProtectedScopeAcceptsBearerAuth(t *testing.T) {
+	for _, authHeader := range []string{"Bearer secret", "bearer secret", "BeArEr secret"} {
+		t.Run(authHeader, func(t *testing.T) {
+			goPort := freePort(t)
+			npmPort := freePort(t)
+			upstream := newFakeNPMRegistry(t)
+
+			cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "0"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.protected_scopes]]
+scope = "@toru"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+			proc := startToruProcess(t, cfgText)
+			defer stopCmd(t, proc)
+
+			waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+			url := fmt.Sprintf("http://127.0.0.1:%d/%%40toru%%2Ffixture-scoped", npmPort)
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Fatalf("new bearer request: %v", err)
+			}
+			req.Header.Set("Authorization", authHeader)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("bearer protected metadata request: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("bearer protected metadata status=%d, want 200", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestNPMProtectedScopeMetadataCacheStillRequiresAuth(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.protected_scopes]]
+scope = "@toru"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/%%40toru%%2Ffixture-scoped", npmPort)
+	reqWarm, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new warm request: %v", err)
+	}
+	reqWarm.SetBasicAuth("static", "secret")
+	respWarm, err := http.DefaultClient.Do(reqWarm)
+	if err != nil {
+		t.Fatalf("warm protected metadata request: %v", err)
+	}
+	respWarm.Body.Close()
+	if respWarm.StatusCode != http.StatusOK {
+		t.Fatalf("warm protected metadata status=%d, want 200", respWarm.StatusCode)
+	}
+
+	resp2, _, err := getURL(url)
+	if err != nil {
+		t.Fatalf("unauthenticated cached metadata request: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated cached metadata status=%d, want 401", resp2.StatusCode)
+	}
+}
+
 func TestNPMTarballMissFetchesFromUpstreamAndCaches(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)

--- a/npm_e2e_test.go
+++ b/npm_e2e_test.go
@@ -389,66 +389,6 @@ base_url = "http://127.0.0.1:%d"
 	}
 }
 
-func TestNPMMetadataCacheDisabledByNonDiskBackend(t *testing.T) {
-	goPort := freePort(t)
-	npmPort := freePort(t)
-	var metadataHits atomic.Int32
-	upstream := newCountingFakeNPMRegistryWithCounters(t, &metadataHits, nil, nil, nil)
-
-	cfgText := fmt.Sprintf(`[server]
-address = ":%d"
-log_level = "info"
-fetch_timeout = "30s"
-
-[[listeners]]
-name = "go"
-address = ":%d"
-protocols = ["go"]
-
-[[listeners]]
-name = "npm"
-address = ":%d"
-protocols = ["npm"]
-
-[cache]
-enabled = true
-type = "s3"
-mutable_metadata_ttl = "0s"
-
-[cache.disk]
-path = %q
-
-[protocols.go]
-enabled = true
-fetch_timeout = "30s"
-
-[protocols.npm]
-enabled = true
-upstream = %q
-metadata_ttl = "5m"
-base_url = "http://127.0.0.1:%d"
-`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
-	proc := startToruProcess(t, cfgText)
-	defer stopCmd(t, proc)
-
-	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
-
-	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort)
-	resp1, _, err := getURL(url)
-	if err != nil {
-		t.Fatalf("first metadata request: %v", err)
-	}
-	resp1.Body.Close()
-	resp2, _, err := getURL(url)
-	if err != nil {
-		t.Fatalf("second metadata request: %v", err)
-	}
-	resp2.Body.Close()
-	if hits := metadataHits.Load(); hits != 2 {
-		t.Fatalf("upstream metadata hits with non-disk backend = %d, want 2", hits)
-	}
-}
-
 func TestNPMProtectedScopeRequiresAuth(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)

--- a/npm_e2e_test.go
+++ b/npm_e2e_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -48,5 +50,71 @@ func TestNPMTarballMissFetchesFromUpstreamAndCaches(t *testing.T) {
 	}
 	if hits := tarballHits.Load(); hits != 1 {
 		t.Fatalf("upstream tarball hits after cached request = %d, want still 1", hits)
+	}
+}
+
+func TestNPMTarballServedEvenWhenCacheWriteFails(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var tarballHits atomic.Int32
+	upstream := newCountingFakeNPMRegistry(t, &tarballHits)
+
+	badCacheRoot := filepath.Join(t.TempDir(), "cache-file")
+	if err := os.WriteFile(badCacheRoot, []byte("not-a-directory"), 0o644); err != nil {
+		t.Fatalf("write bad cache root: %v", err)
+	}
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, badCacheRoot, upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", npmPort)
+	resp, body, err := getURL(url)
+	if err != nil {
+		t.Fatalf("tarball request with bad cache root: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200 despite cache write failure", resp.StatusCode, body)
+	}
+	if body != "fake-tgz-unscoped" {
+		t.Fatalf("body=%q, want upstream tarball body", body)
+	}
+	if hits := tarballHits.Load(); hits != 1 {
+		t.Fatalf("upstream tarball hits = %d, want 1", hits)
 	}
 }

--- a/npm_e2e_test.go
+++ b/npm_e2e_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Verification contract:
+// npm mode must fetch from upstream on first tarball request and then satisfy a
+// repeat request from cache without another upstream tarball fetch.
+
+func TestNPMTarballMissFetchesFromUpstreamAndCaches(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var tarballHits atomic.Int32
+	upstream := newCountingFakeNPMRegistry(t, &tarballHits)
+
+	cfgText := testMixedModeConfig(t, goPort, npmPort, upstream.URL)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", npmPort)
+
+	resp1, body1, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first tarball request: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first tarball status=%d body=%q, want 200", resp1.StatusCode, body1)
+	}
+	if hits := tarballHits.Load(); hits != 1 {
+		t.Fatalf("upstream tarball hits after first request = %d, want 1", hits)
+	}
+
+	resp2, body2, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second tarball request: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second tarball status=%d body=%q, want 200", resp2.StatusCode, body2)
+	}
+	if hits := tarballHits.Load(); hits != 1 {
+		t.Fatalf("upstream tarball hits after cached request = %d, want still 1", hits)
+	}
+}

--- a/npm_e2e_test.go
+++ b/npm_e2e_test.go
@@ -195,7 +195,7 @@ fetch_timeout = "30s"
 [protocols.npm]
 enabled = true
 upstream = %q
-metadata_ttl = "1ms"
+metadata_ttl = "1h"
 base_url = "http://127.0.0.1:%d"
 `, goPort, goPort, npmPort, cacheRoot, upstream.URL, npmPort)
 	proc := startToruProcess(t, cfgText)
@@ -224,7 +224,11 @@ base_url = "http://127.0.0.1:%d"
 		t.Fatalf("etag sidecar = %q, want %q", string(etagBytes), `"toru-fixture-etag"`)
 	}
 
-	time.Sleep(10 * time.Millisecond)
+	expiryPath := filepath.Join(cacheRoot, "npm-meta", "toru-fixture-pkg.expiry")
+	staleExpiry := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339Nano)
+	if err := os.WriteFile(expiryPath, []byte(staleExpiry), 0o644); err != nil {
+		t.Fatalf("write stale expiry sidecar: %v", err)
+	}
 
 	resp2, body2, err := getURL(url)
 	if err != nil {

--- a/npm_e2e_test.go
+++ b/npm_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -586,6 +587,89 @@ func TestNPMScopedTarballUsesDecodedUpstreamPathAndCaches(t *testing.T) {
 	}
 	if hits := scopedHits.Load(); hits != 1 {
 		t.Fatalf("scoped upstream tarball hits after cached request = %d, want still 1", hits)
+	}
+}
+
+func TestNPMTarballCacheDisabledDoesNotPersistOrEmitArtifactCacheMetrics(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var tarballHits atomic.Int32
+	upstream := newCountingFakeNPMRegistry(t, &tarballHits)
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = false
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, cacheRoot, upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", npmPort)
+	resp1, body1, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first tarball request: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first tarball status=%d body=%q, want 200", resp1.StatusCode, body1)
+	}
+	resp2, body2, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second tarball request: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second tarball status=%d body=%q, want 200", resp2.StatusCode, body2)
+	}
+	if hits := tarballHits.Load(); hits != 2 {
+		t.Fatalf("upstream tarball hits with cache disabled = %d, want 2", hits)
+	}
+	if _, err := os.Stat(filepath.Join(cacheRoot, "npm", "toru-fixture-pkg", "toru-fixture-pkg-1.0.0.tgz")); !os.IsNotExist(err) {
+		t.Fatalf("tarball cache file should not be written when cache is disabled, err=%v", err)
+	}
+	_, metricsBody, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort))
+	if err != nil {
+		t.Fatalf("scrape metrics: %v", err)
+	}
+	if strings.Contains(metricsBody, `toru_cache_writes_by_protocol_total{protocol="npm",class="artifact"}`) {
+		t.Fatalf("artifact cache write metric should not be emitted when cache is disabled, body=%q", metricsBody)
+	}
+	if strings.Contains(metricsBody, `toru_cache_hits_by_protocol_total{protocol="npm",class="artifact"}`) {
+		t.Fatalf("artifact cache hit metric should not be emitted when cache is disabled, body=%q", metricsBody)
+	}
+	if strings.Contains(metricsBody, `toru_cache_misses_by_protocol_total{protocol="npm",class="artifact"}`) {
+		t.Fatalf("artifact cache miss metric should not be emitted when cache is disabled, body=%q", metricsBody)
 	}
 }
 

--- a/npm_e2e_test.go
+++ b/npm_e2e_test.go
@@ -14,6 +14,265 @@ import (
 // npm mode must fetch from upstream on first tarball request and then satisfy a
 // repeat request from cache without another upstream tarball fetch.
 
+func TestNPMMetadataFreshHitUsesCache(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var metadataHits atomic.Int32
+	upstream := newCountingFakeNPMRegistryWithCounters(t, &metadataHits, nil, nil, nil)
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort)
+	resp1, body1, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first metadata request: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first metadata status=%d body=%q, want 200", resp1.StatusCode, body1)
+	}
+	if hits := metadataHits.Load(); hits != 1 {
+		t.Fatalf("upstream metadata hits after first request = %d, want 1", hits)
+	}
+
+	resp2, body2, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second metadata request: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second metadata status=%d body=%q, want 200", resp2.StatusCode, body2)
+	}
+	if hits := metadataHits.Load(); hits != 1 {
+		t.Fatalf("upstream metadata hits after cached request = %d, want still 1", hits)
+	}
+}
+
+func TestNPMMetadataStaleRefreshesUpstream(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var metadataHits atomic.Int32
+	upstream := newCountingFakeNPMRegistryWithCounters(t, &metadataHits, nil, nil, nil)
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "1ms"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort)
+	resp1, _, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first metadata request: %v", err)
+	}
+	resp1.Body.Close()
+	if hits := metadataHits.Load(); hits != 1 {
+		t.Fatalf("upstream metadata hits after first request = %d, want 1", hits)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	resp2, body2, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second metadata request: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second metadata status=%d body=%q, want 200", resp2.StatusCode, body2)
+	}
+	if hits := metadataHits.Load(); hits != 2 {
+		t.Fatalf("upstream metadata hits after stale refresh = %d, want 2", hits)
+	}
+}
+
+func TestNPMMetadataCacheDisabledByCacheConfig(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var metadataHits atomic.Int32
+	upstream := newCountingFakeNPMRegistryWithCounters(t, &metadataHits, nil, nil, nil)
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = false
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort)
+	resp1, _, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first metadata request: %v", err)
+	}
+	resp1.Body.Close()
+	resp2, _, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second metadata request: %v", err)
+	}
+	resp2.Body.Close()
+	if hits := metadataHits.Load(); hits != 2 {
+		t.Fatalf("upstream metadata hits with cache disabled = %d, want 2", hits)
+	}
+}
+
+func TestNPMMetadataCacheDisabledByNonDiskBackend(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var metadataHits atomic.Int32
+	upstream := newCountingFakeNPMRegistryWithCounters(t, &metadataHits, nil, nil, nil)
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "s3"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort)
+	resp1, _, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first metadata request: %v", err)
+	}
+	resp1.Body.Close()
+	resp2, _, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second metadata request: %v", err)
+	}
+	resp2.Body.Close()
+	if hits := metadataHits.Load(); hits != 2 {
+		t.Fatalf("upstream metadata hits with non-disk backend = %d, want 2", hits)
+	}
+}
+
 func TestNPMTarballMissFetchesFromUpstreamAndCaches(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)
@@ -50,6 +309,48 @@ func TestNPMTarballMissFetchesFromUpstreamAndCaches(t *testing.T) {
 	}
 	if hits := tarballHits.Load(); hits != 1 {
 		t.Fatalf("upstream tarball hits after cached request = %d, want still 1", hits)
+	}
+}
+
+func TestNPMScopedTarballUsesDecodedUpstreamPathAndCaches(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	var unscopedHits atomic.Int32
+	var scopedHits atomic.Int32
+	upstream := newCountingFakeNPMRegistryWithCounters(t, nil, nil, &unscopedHits, &scopedHits)
+
+	cfgText := testMixedModeConfig(t, goPort, npmPort, upstream.URL)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/%%40toru%%2Ffixture-scoped/-/fixture-scoped-1.0.0.tgz", npmPort)
+	resp1, body1, err := getURL(url)
+	if err != nil {
+		t.Fatalf("first scoped tarball request: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first scoped tarball status=%d body=%q, want 200", resp1.StatusCode, body1)
+	}
+	if hits := scopedHits.Load(); hits != 1 {
+		t.Fatalf("scoped upstream tarball hits after first request = %d, want 1", hits)
+	}
+	if hits := unscopedHits.Load(); hits != 0 {
+		t.Fatalf("unscoped upstream tarball hits after scoped request = %d, want 0", hits)
+	}
+
+	resp2, body2, err := getURL(url)
+	if err != nil {
+		t.Fatalf("second scoped tarball request: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second scoped tarball status=%d body=%q, want 200", resp2.StatusCode, body2)
+	}
+	if hits := scopedHits.Load(); hits != 1 {
+		t.Fatalf("scoped upstream tarball hits after cached request = %d, want still 1", hits)
 	}
 }
 

--- a/npm_gitlab.go
+++ b/npm_gitlab.go
@@ -114,20 +114,33 @@ func (h *npmHandler) fetchGitLabVersions(r *http.Request, pkg string, rule NPMRe
 
 func (h *npmHandler) fetchGitLabTags(r *http.Request, rule NPMRewriteRule, repoPath, gitlabToken string) ([]gitLabTag, error) {
 	projectPath := url.PathEscape(repoPath)
-	endpoint := h.gitLabRuleBaseURL(rule) + "/api/v4/projects/" + projectPath + "/repository/tags"
-	resp, body, err := h.doAuthorizedUpstreamGet(r, endpoint, gitlabToken)
-	if err != nil {
-		return nil, err
+	baseEndpoint := h.gitLabRuleBaseURL(rule) + "/api/v4/projects/" + projectPath + "/repository/tags"
+	allTags := make([]gitLabTag, 0)
+	nextPageToken := "1"
+	for {
+		endpoint := fmt.Sprintf("%s?page=%s&per_page=100", baseEndpoint, url.QueryEscape(nextPageToken))
+		resp, body, err := h.doAuthorizedUpstreamGet(r, endpoint, gitlabToken)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, gitLabHTTPError{StatusCode: mapGitLabStatus(resp.StatusCode), Message: string(body)}
+		}
+		var tags []gitLabTag
+		if err := json.Unmarshal(body, &tags); err != nil {
+			resp.Body.Close()
+			return nil, err
+		}
+		allTags = append(allTags, tags...)
+		nextPage := strings.TrimSpace(resp.Header.Get("X-Next-Page"))
+		resp.Body.Close()
+		if nextPage == "" || len(tags) == 0 {
+			break
+		}
+		nextPageToken = nextPage
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, gitLabHTTPError{StatusCode: mapGitLabStatus(resp.StatusCode), Message: string(body)}
-	}
-	var tags []gitLabTag
-	if err := json.Unmarshal(body, &tags); err != nil {
-		return nil, err
-	}
-	return tags, nil
+	return allTags, nil
 }
 
 func (h *npmHandler) fetchGitLabManifest(r *http.Request, rule NPMRewriteRule, repoPath, tag, gitlabToken string) (map[string]any, error) {

--- a/npm_gitlab.go
+++ b/npm_gitlab.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"slices"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+type gitLabTag struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+}
+
+type gitLabPackageVersion struct {
+	Version  string
+	Tag      string
+	Manifest map[string]any
+}
+
+func (h *npmHandler) synthesizeRewrittenMetadata(r *http.Request, pkg string, rule NPMRewriteRule) ([]byte, int, error) {
+	repoPath, err := repoPathForPackage(rule, pkg)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	_, gitlabToken, ok := authorizeRequestToken(r, rule.AuthModule)
+	if !ok {
+		return nil, http.StatusUnauthorized, fmt.Errorf("no username or password provided")
+	}
+	versions, err := h.fetchGitLabVersions(r, pkg, rule, repoPath, gitlabToken)
+	if err != nil {
+		var httpErr gitLabHTTPError
+		if ok := errorAs(err, &httpErr); ok {
+			return nil, httpErr.StatusCode, fmt.Errorf("%s", httpErr.Message)
+		}
+		return nil, http.StatusBadGateway, err
+	}
+	if len(versions) == 0 {
+		return nil, http.StatusNotFound, fmt.Errorf("no valid semver tags found for %s", repoPath)
+	}
+	return synthesizeNPMRewriteMetadata(pkg, h.cfg.Protocols.NPM.BaseURL, versions)
+}
+
+func (h *npmHandler) fetchGitLabVersions(r *http.Request, pkg string, rule NPMRewriteRule, repoPath, gitlabToken string) ([]gitLabPackageVersion, error) {
+	tags, err := h.fetchGitLabTags(r, rule, repoPath, gitlabToken)
+	if err != nil {
+		return nil, err
+	}
+	versionToTag := map[string]string{}
+	versionToTarget := map[string]string{}
+	orderedVersions := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		version, ok := normalizeGitTagVersion(tag.Name)
+		if !ok {
+			continue
+		}
+		if existingTag, ok := versionToTag[version]; ok {
+			existingTarget := versionToTarget[version]
+			candidateTarget := tag.Target
+			if existingTarget == "" {
+				existingTarget = existingTag
+			}
+			if candidateTarget == "" {
+				candidateTarget = tag.Name
+			}
+			if existingTarget != candidateTarget {
+				return nil, fmt.Errorf("ambiguous tags for version %s: %s, %s", version, existingTag, tag.Name)
+			}
+			versionToTag[version] = preferredGitTag(existingTag, tag.Name, version)
+			continue
+		}
+		orderedVersions = append(orderedVersions, version)
+		versionToTag[version] = tag.Name
+		if tag.Target != "" {
+			versionToTarget[version] = tag.Target
+		}
+	}
+	slices.SortFunc(orderedVersions, func(a, b string) int {
+		if semver.Compare(a, b) > 0 {
+			return -1
+		}
+		if semver.Compare(a, b) < 0 {
+			return 1
+		}
+		return 0
+	})
+	versions := make([]gitLabPackageVersion, 0, len(orderedVersions))
+	for _, version := range orderedVersions {
+		manifest, err := h.fetchGitLabManifest(r, rule, repoPath, versionToTag[version], gitlabToken)
+		if err != nil {
+			return nil, err
+		}
+		name, _ := manifest["name"].(string)
+		if name != pkg {
+			return nil, fmt.Errorf("package.json name mismatch for %s at %s: got %q want %q", repoPath, versionToTag[version], name, pkg)
+		}
+		versions = append(versions, gitLabPackageVersion{
+			Version:  strings.TrimPrefix(version, "v"),
+			Tag:      versionToTag[version],
+			Manifest: manifest,
+		})
+	}
+	return versions, nil
+}
+
+func (h *npmHandler) fetchGitLabTags(r *http.Request, rule NPMRewriteRule, repoPath, gitlabToken string) ([]gitLabTag, error) {
+	projectPath := url.PathEscape(repoPath)
+	endpoint := h.gitLabRuleBaseURL(rule) + "/api/v4/projects/" + projectPath + "/repository/tags"
+	resp, body, err := h.doAuthorizedUpstreamGet(r, endpoint, gitlabToken)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, gitLabHTTPError{StatusCode: mapGitLabStatus(resp.StatusCode), Message: string(body)}
+	}
+	var tags []gitLabTag
+	if err := json.Unmarshal(body, &tags); err != nil {
+		return nil, err
+	}
+	return tags, nil
+}
+
+func (h *npmHandler) fetchGitLabManifest(r *http.Request, rule NPMRewriteRule, repoPath, tag, gitlabToken string) (map[string]any, error) {
+	projectPath := url.PathEscape(repoPath)
+	endpoint := h.gitLabRuleBaseURL(rule) + "/api/v4/projects/" + projectPath + "/repository/archive.tar.gz?sha=" + url.QueryEscape(tag)
+	resp, body, err := h.doAuthorizedUpstreamGet(r, endpoint, gitlabToken)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, gitLabHTTPError{StatusCode: mapGitLabStatus(resp.StatusCode), Message: string(body)}
+	}
+	return extractRootPackageJSON(body)
+}
+
+func extractRootPackageJSON(body []byte) (map[string]any, error) {
+	gz, err := gzip.NewReader(strings.NewReader(string(body)))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		clean := path.Clean(hdr.Name)
+		parts := strings.Split(clean, "/")
+		if len(parts) == 2 && parts[1] == "package.json" {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, err
+			}
+			var manifest map[string]any
+			if err := json.Unmarshal(data, &manifest); err != nil {
+				return nil, err
+			}
+			return manifest, nil
+		}
+	}
+	return nil, fmt.Errorf("root package.json not found in archive")
+}
+
+func preferredGitTag(existing, candidate, version string) string {
+	exact := strings.TrimPrefix(version, "v")
+	if candidate == exact {
+		return candidate
+	}
+	if existing == exact {
+		return existing
+	}
+	return existing
+}
+
+func normalizeGitTagVersion(tag string) (string, bool) {
+	if tag == "" {
+		return "", false
+	}
+	version := tag
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	if !semver.IsValid(version) {
+		return "", false
+	}
+	return version, true
+}
+
+func (h *npmHandler) gitLabRuleBaseURL(rule NPMRewriteRule) string {
+	host := strings.TrimSpace(rule.TargetHost)
+	if strings.HasPrefix(host, "127.0.0.1:") || strings.HasPrefix(host, "localhost:") {
+		return "http://" + host
+	}
+	return "https://" + host
+}
+
+type gitLabHTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e gitLabHTTPError) Error() string { return e.Message }
+
+func mapGitLabStatus(status int) int {
+	switch status {
+	case http.StatusNotFound:
+		return http.StatusNotFound
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return http.StatusForbidden
+	default:
+		return http.StatusBadGateway
+	}
+}
+
+func errorAs(err error, target *gitLabHTTPError) bool {
+	httpErr, ok := err.(gitLabHTTPError)
+	if !ok {
+		return false
+	}
+	*target = httpErr
+	return true
+}

--- a/npm_gitlab.go
+++ b/npm_gitlab.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -130,6 +131,14 @@ func (h *npmHandler) fetchGitLabTags(r *http.Request, rule NPMRewriteRule, repoP
 }
 
 func (h *npmHandler) fetchGitLabManifest(r *http.Request, rule NPMRewriteRule, repoPath, tag, gitlabToken string) (map[string]any, error) {
+	body, err := h.fetchGitLabArchive(r, rule, repoPath, tag, gitlabToken)
+	if err != nil {
+		return nil, err
+	}
+	return extractRootPackageJSON(body)
+}
+
+func (h *npmHandler) fetchGitLabArchive(r *http.Request, rule NPMRewriteRule, repoPath, tag, gitlabToken string) ([]byte, error) {
 	projectPath := url.PathEscape(repoPath)
 	endpoint := h.gitLabRuleBaseURL(rule) + "/api/v4/projects/" + projectPath + "/repository/archive.tar.gz?sha=" + url.QueryEscape(tag)
 	resp, body, err := h.doAuthorizedUpstreamGet(r, endpoint, gitlabToken)
@@ -140,11 +149,11 @@ func (h *npmHandler) fetchGitLabManifest(r *http.Request, rule NPMRewriteRule, r
 	if resp.StatusCode != http.StatusOK {
 		return nil, gitLabHTTPError{StatusCode: mapGitLabStatus(resp.StatusCode), Message: string(body)}
 	}
-	return extractRootPackageJSON(body)
+	return body, nil
 }
 
 func extractRootPackageJSON(body []byte) (map[string]any, error) {
-	gz, err := gzip.NewReader(strings.NewReader(string(body)))
+	gz, err := gzip.NewReader(bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -198,6 +207,77 @@ func normalizeGitTagVersion(tag string) (string, bool) {
 		return "", false
 	}
 	return version, true
+}
+
+func (h *npmHandler) synthesizeRewrittenTarball(r *http.Request, pkg, filename string, rule NPMRewriteRule, gitlabToken string) ([]byte, int, error) {
+	repoPath, err := repoPathForPackage(rule, pkg)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	version, err := rewrittenTarballVersion(pkg, filename)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	tag, err := h.resolveGitLabVersionTag(r, rule, repoPath, version, gitlabToken)
+	if err != nil {
+		var httpErr gitLabHTTPError
+		if ok := errorAs(err, &httpErr); ok {
+			return nil, httpErr.StatusCode, fmt.Errorf("%s", httpErr.Message)
+		}
+		return nil, http.StatusBadGateway, err
+	}
+	archive, err := h.fetchGitLabArchive(r, rule, repoPath, tag, gitlabToken)
+	if err != nil {
+		var httpErr gitLabHTTPError
+		if ok := errorAs(err, &httpErr); ok {
+			return nil, httpErr.StatusCode, fmt.Errorf("%s", httpErr.Message)
+		}
+		return nil, http.StatusBadGateway, err
+	}
+	body, err := synthesizeNPMTarballFromGitLabArchive(pkg, archive)
+	if err != nil {
+		return nil, http.StatusBadGateway, err
+	}
+	return body, http.StatusOK, nil
+}
+
+func (h *npmHandler) resolveGitLabVersionTag(r *http.Request, rule NPMRewriteRule, repoPath, requestedVersion, gitlabToken string) (string, error) {
+	tags, err := h.fetchGitLabTags(r, rule, repoPath, gitlabToken)
+	if err != nil {
+		return "", err
+	}
+	normalizedRequested, ok := normalizeGitTagVersion(requestedVersion)
+	if !ok {
+		return "", fmt.Errorf("invalid requested version %q", requestedVersion)
+	}
+	chosenTag := ""
+	chosenTarget := ""
+	for _, tag := range tags {
+		normalizedTag, ok := normalizeGitTagVersion(tag.Name)
+		if !ok || normalizedTag != normalizedRequested {
+			continue
+		}
+		if chosenTag == "" {
+			chosenTag = tag.Name
+			chosenTarget = tag.Target
+			if chosenTarget == "" {
+				chosenTarget = tag.Name
+			}
+			continue
+		}
+		candidateTarget := tag.Target
+		if candidateTarget == "" {
+			candidateTarget = tag.Name
+		}
+		if chosenTarget != candidateTarget {
+			return "", fmt.Errorf("ambiguous tags for version %s: %s, %s", normalizedRequested, chosenTag, tag.Name)
+		}
+		chosenTag = preferredGitTag(chosenTag, tag.Name, normalizedRequested)
+	}
+	if chosenTag == "" {
+		return "", gitLabHTTPError{StatusCode: http.StatusNotFound, Message: fmt.Sprintf("version %s not found for %s", requestedVersion, repoPath)}
+	}
+	return chosenTag, nil
 }
 
 func (h *npmHandler) gitLabRuleBaseURL(rule NPMRewriteRule) string {

--- a/npm_gitlab_e2e_test.go
+++ b/npm_gitlab_e2e_test.go
@@ -1,0 +1,707 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeGitLabRepo struct {
+	Tags       []string
+	TagTargets map[string]string
+	Archives   map[string]map[string]string
+}
+
+type fakeGitLabRegistry struct {
+	server *httptest.Server
+}
+
+func newFakeGitLabRegistry(t *testing.T, repos map[string]fakeGitLabRepo) *fakeGitLabRegistry {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
+		trimmed := strings.TrimPrefix(r.URL.Path, "/api/v4/projects/")
+		if strings.HasSuffix(trimmed, "/repository/tags") {
+			projectPath, err := url.PathUnescape(strings.TrimSuffix(trimmed, "/repository/tags"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			repo, ok := repos[projectPath]
+			if !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			payload := make([]map[string]string, 0, len(repo.Tags))
+			for _, tag := range repo.Tags {
+				entry := map[string]string{"name": tag}
+				if target := repo.TagTargets[tag]; target != "" {
+					entry["target"] = target
+				}
+				payload = append(payload, entry)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(payload)
+			return
+		}
+		if strings.HasSuffix(trimmed, "/repository/archive.tar.gz") {
+			projectPath, err := url.PathUnescape(strings.TrimSuffix(trimmed, "/repository/archive.tar.gz"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			repo, ok := repos[projectPath]
+			if !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			tag := r.URL.Query().Get("sha")
+			files, ok := repo.Archives[tag]
+			if !ok {
+				http.Error(w, "archive not found", http.StatusNotFound)
+				return
+			}
+			archive, err := makeGitLabArchive(filepath.Base(projectPath)+"-"+tag, files)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archive)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+	return &fakeGitLabRegistry{server: httptest.NewServer(mux)}
+}
+
+func (f *fakeGitLabRegistry) Close()       { f.server.Close() }
+func (f *fakeGitLabRegistry) Host() string { return strings.TrimPrefix(f.server.URL, "http://") }
+
+func makeGitLabArchive(root string, files map[string]string) ([]byte, error) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		data := []byte(content)
+		hdr := &tar.Header{Name: root + "/" + name, Mode: 0o644, Size: int64(len(data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(data); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func TestNPMRewriteMetadataSynthesizesFromGitLabTags(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags: []string{"v1.0.0", "v1.2.0", "1.3.0", "main"},
+			Archives: map[string]map[string]string{
+				"v1.0.0": {"package.json": `{"name":"@example-commons/foo","main":"index.js"}`},
+				"v1.2.0": {"package.json": `{"name":"@example-commons/foo","dependencies":{"is-number":"^7.0.0"}}`},
+				"1.3.0":  {"package.json": `{"name":"@example-commons/foo","exports":"./index.js"}`},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo", npmPort), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request rewritten metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200", resp.StatusCode, string(body))
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if doc["name"] != "@example-commons/foo" {
+		t.Fatalf("name=%v, want @example-commons/foo", doc["name"])
+	}
+	distTags := doc["dist-tags"].(map[string]any)
+	if distTags["latest"] != "1.3.0" {
+		t.Fatalf("latest=%v, want 1.3.0", distTags["latest"])
+	}
+	versions := doc["versions"].(map[string]any)
+	if len(versions) != 3 {
+		t.Fatalf("versions len=%d, want 3", len(versions))
+	}
+	v130 := versions["1.3.0"].(map[string]any)
+	dist := v130["dist"].(map[string]any)
+	wantTarball := fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo/-/foo-1.3.0.tgz", npmPort)
+	if dist["tarball"] != wantTarball {
+		t.Fatalf("tarball=%v, want %q", dist["tarball"], wantTarball)
+	}
+}
+
+func TestNPMRewriteMetadataCoexistsWithUpstreamProxy(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags: []string{"v1.0.0"},
+			Archives: map[string]map[string]string{
+				"v1.0.0": {"package.json": `{"name":"@example-commons/foo"}`},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo", npmPort), nil)
+	req.SetBasicAuth("static", "secret")
+	respRewrite, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request rewritten metadata: %v", err)
+	}
+	respRewrite.Body.Close()
+	if respRewrite.StatusCode != http.StatusOK {
+		t.Fatalf("rewrite status=%d, want 200", respRewrite.StatusCode)
+	}
+
+	respPublic, bodyPublic, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort))
+	if err != nil {
+		t.Fatalf("request public metadata: %v", err)
+	}
+	defer respPublic.Body.Close()
+	if respPublic.StatusCode != http.StatusOK {
+		t.Fatalf("public status=%d body=%q, want 200", respPublic.StatusCode, bodyPublic)
+	}
+}
+
+func TestNPMRewriteMetadataRejectsManifestNameMismatch(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/bad-name": {
+			Tags: []string{"v1.0.0"},
+			Archives: map[string]map[string]string{
+				"v1.0.0": {"package.json": `{"name":"@someone-else/bad-name"}`},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Fbad-name", npmPort), nil)
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request mismatch metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%q, want 502", resp.StatusCode, string(body))
+	}
+}
+
+func TestNPMRewriteMetadataPrefersExactTagWhenDuplicateTargetsMatch(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags: []string{"v1.2.3", "1.2.3"},
+			TagTargets: map[string]string{
+				"v1.2.3": "abc123",
+				"1.2.3":  "abc123",
+			},
+			Archives: map[string]map[string]string{
+				"1.2.3":  {"package.json": `{"name":"@example-commons/foo"}`},
+				"v1.2.3": {"package.json": `{"name":"@example-commons/foo"}`},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo", npmPort), nil)
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request duplicate-target metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200", resp.StatusCode, string(body))
+	}
+}
+
+func TestNPMRewriteMetadataRejectsAmbiguousDuplicateVersionTags(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags: []string{"v1.2.3", "1.2.3"},
+			TagTargets: map[string]string{
+				"v1.2.3": "abc123",
+				"1.2.3":  "def456",
+			},
+			Archives: map[string]map[string]string{
+				"1.2.3":  {"package.json": `{"name":"@example-commons/foo"}`},
+				"v1.2.3": {"package.json": `{"name":"@example-commons/foo"}`},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo", npmPort), nil)
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request ambiguous duplicate metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%q, want 502", resp.StatusCode, string(body))
+	}
+}
+
+func TestNPMRewriteMetadataFailsWhenRootPackageJSONMissing(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/missing-manifest": {
+			Tags: []string{"v1.0.0"},
+			Archives: map[string]map[string]string{
+				"v1.0.0": {"README.md": "hello"},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Fmissing-manifest", npmPort), nil)
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request missing-manifest metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%q, want 502", resp.StatusCode, string(body))
+	}
+}
+
+func TestNPMRewriteMetadataReturns404WithoutValidSemverTags(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"utils/no-tags": {
+			Tags:     []string{"main", "release-candidate"},
+			Archives: map[string]map[string]string{},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-utils"
+target_host = %q
+target_group = "utils"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40zerodha-utils%%2Fno-tags", npmPort), nil)
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request no-tags metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d body=%q, want 404", resp.StatusCode, string(body))
+	}
+}

--- a/npm_gitlab_e2e_test.go
+++ b/npm_gitlab_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -1156,6 +1157,132 @@ auth_module = "static"
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusBadGateway {
 		t.Fatalf("status=%d body=%q, want 502", resp.StatusCode, string(body))
+	}
+}
+
+func TestNPMRewriteRealClientPNPMSmoke(t *testing.T) {
+	if _, err := exec.LookPath("pnpm"); err != nil {
+		t.Skip("pnpm not available")
+	}
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags: []string{"v1.0.0"},
+			Archives: map[string]map[string]string{
+				"v1.0.0": {
+					"package.json": `{"name":"@example-commons/foo","version":"1.0.0","main":"index.js"}`,
+					"index.js":     `module.exports = 42`,
+				},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, cacheRoot, upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	writeProject := func(projectDir string) {
+		t.Helper()
+		if err := os.MkdirAll(projectDir, 0o755); err != nil {
+			t.Fatalf("mkdir project dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{"name":"pnpm-rewrite-smoke","version":"1.0.0","private":true}`), 0o644); err != nil {
+			t.Fatalf("write package.json: %v", err)
+		}
+		npmrc := fmt.Sprintf("registry=http://127.0.0.1:%d\n//127.0.0.1:%d/:_authToken=secret\nalways-auth=true\n", npmPort, npmPort)
+		if err := os.WriteFile(filepath.Join(projectDir, ".npmrc"), []byte(npmrc), 0o644); err != nil {
+			t.Fatalf("write .npmrc: %v", err)
+		}
+	}
+	runAdd := func(projectDir, storeDir string) {
+		t.Helper()
+		cmd := exec.Command("pnpm", "add", "@example-commons/foo", "--store-dir", storeDir)
+		cmd.Dir = projectDir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("pnpm add failed in %s: %v\n%s", projectDir, err, string(output))
+		}
+		installed, err := os.ReadFile(filepath.Join(projectDir, "node_modules", "@example-commons", "foo", "package.json"))
+		if err != nil {
+			t.Fatalf("read installed package.json in %s: %v\n%s", projectDir, err, string(output))
+		}
+		if !strings.Contains(string(installed), `"name":"@example-commons/foo"`) {
+			t.Fatalf("installed package.json in %s = %q, want rewrite package name", projectDir, string(installed))
+		}
+	}
+
+	projectOne := filepath.Join(t.TempDir(), "pnpm-rewrite-smoke-1")
+	storeOne := filepath.Join(t.TempDir(), "pnpm-store-1")
+	writeProject(projectOne)
+	runAdd(projectOne, storeOne)
+	cacheFile := filepath.Join(cacheRoot, "npm-rewrite", strings.ReplaceAll(gitlab.Host(), ":", "_"), "commons", npmCachePackageKey("@example-commons/foo"), "foo-1.0.0.tgz")
+	if _, err := os.Stat(cacheFile); err != nil {
+		t.Fatalf("rewrite tarball cache file %q missing after first install: %v", cacheFile, err)
+	}
+
+	projectTwo := filepath.Join(t.TempDir(), "pnpm-rewrite-smoke-2")
+	storeTwo := filepath.Join(t.TempDir(), "pnpm-store-2")
+	writeProject(projectTwo)
+	runAdd(projectTwo, storeTwo)
+
+	_, metricsBody, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort))
+	if err != nil {
+		t.Fatalf("scrape metrics: %v", err)
+	}
+	if !strings.Contains(metricsBody, `toru_cache_hits_by_protocol_total{protocol="npm",class="artifact"}`) {
+		t.Fatalf("expected npm artifact cache hit metric after second install, body=%q", metricsBody)
 	}
 }
 

--- a/npm_gitlab_e2e_test.go
+++ b/npm_gitlab_e2e_test.go
@@ -10,16 +10,19 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
 type fakeGitLabRepo struct {
-	Tags       []string
-	TagTargets map[string]string
-	Archives   map[string]map[string]string
+	Tags        []string
+	TagTargets  map[string]string
+	Archives    map[string]map[string]string
+	ArchiveHits *atomic.Int32
 }
 
 type fakeGitLabRegistry struct {
@@ -71,6 +74,9 @@ func newFakeGitLabRegistry(t *testing.T, repos map[string]fakeGitLabRepo) *fakeG
 				http.Error(w, "archive not found", http.StatusNotFound)
 				return
 			}
+			if repo.ArchiveHits != nil {
+				repo.ArchiveHits.Add(1)
+			}
 			archive, err := makeGitLabArchive(filepath.Base(projectPath)+"-"+tag, files)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -87,6 +93,34 @@ func newFakeGitLabRegistry(t *testing.T, repos map[string]fakeGitLabRepo) *fakeG
 
 func (f *fakeGitLabRegistry) Close()       { f.server.Close() }
 func (f *fakeGitLabRegistry) Host() string { return strings.TrimPrefix(f.server.URL, "http://") }
+
+func readNPMTarballFiles(body []byte) (map[string]string, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	files := map[string]string{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
+			continue
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, err
+		}
+		files[hdr.Name] = string(data)
+	}
+	return files, nil
+}
 
 func makeGitLabArchive(root string, files map[string]string) ([]byte, error) {
 	var buf bytes.Buffer
@@ -547,6 +581,299 @@ auth_module = "static"
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusBadGateway {
 		t.Fatalf("status=%d body=%q, want 502", resp.StatusCode, string(body))
+	}
+}
+
+func TestNPMRewriteTarballSynthesizesPackagePrefixAndCaches(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	var archiveHits atomic.Int32
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags: []string{"v1.2.0"},
+			Archives: map[string]map[string]string{
+				"v1.2.0": {
+					"package.json": `{"name":"@example-commons/foo","main":"index.js"}`,
+					"index.js":     `module.exports = 42`,
+				},
+			},
+			ArchiveHits: &archiveHits,
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo/-/foo-1.2.0.tgz", npmPort)
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.SetBasicAuth("static", "secret")
+	resp1, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("first tarball request: %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first tarball status=%d body=%q, want 200", resp1.StatusCode, string(body1))
+	}
+	if hits := archiveHits.Load(); hits != 1 {
+		t.Fatalf("archive hits after first request = %d, want 1", hits)
+	}
+	files, err := readNPMTarballFiles(body1)
+	if err != nil {
+		t.Fatalf("read synthesized tarball: %v", err)
+	}
+	if _, ok := files["package/package.json"]; !ok {
+		t.Fatalf("expected package/package.json in synthesized tarball, files=%v", files)
+	}
+	if _, ok := files["package/index.js"]; !ok {
+		t.Fatalf("expected package/index.js in synthesized tarball, files=%v", files)
+	}
+
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("second tarball request: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second tarball status=%d body=%q, want 200", resp2.StatusCode, string(body2))
+	}
+	if hits := archiveHits.Load(); hits != 1 {
+		t.Fatalf("archive hits after cached request = %d, want still 1", hits)
+	}
+}
+
+func TestNPMRewriteTarballFailsWhenRootPackageJSONMissing(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/missing-manifest": {
+			Tags: []string{"v1.0.0"},
+			Archives: map[string]map[string]string{
+				"v1.0.0": {"README.md": "hello"},
+			},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Fmissing-manifest/-/missing-manifest-1.0.0.tgz", npmPort), nil)
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request missing-manifest tarball: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%q, want 502", resp.StatusCode, string(body))
+	}
+}
+
+func TestNPMRewriteTarballUsesSeparateCacheNamespaceFromUpstream(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	var archiveHits atomic.Int32
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags: []string{"v1.2.0"},
+			Archives: map[string]map[string]string{
+				"v1.2.0": {
+					"package.json": `{"name":"@example-commons/foo","main":"index.js"}`,
+					"index.js":     `module.exports = 42`,
+				},
+			},
+			ArchiveHits: &archiveHits,
+		},
+	})
+	defer gitlab.Close()
+
+	if err := os.MkdirAll(filepath.Join(cacheRoot, "npm", "%40example-commons%2Ffoo"), 0o755); err != nil {
+		t.Fatalf("mkdir upstream cache path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheRoot, "npm", "%40example-commons%2Ffoo", "foo-1.2.0.tgz"), []byte("upstream-body"), 0o644); err != nil {
+		t.Fatalf("seed upstream cache path: %v", err)
+	}
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, cacheRoot, upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo/-/foo-1.2.0.tgz", npmPort)
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request rewrite tarball: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200", resp.StatusCode, string(body))
+	}
+	if string(body) == "upstream-body" {
+		t.Fatalf("rewrite tarball served stale upstream cache body")
+	}
+	if hits := archiveHits.Load(); hits != 1 {
+		t.Fatalf("archive hits after rewrite tarball request = %d, want 1", hits)
+	}
+	hostKey := strings.ReplaceAll(gitlab.Host(), ":", "_")
+	if _, err := os.Stat(filepath.Join(cacheRoot, "npm-rewrite", hostKey, "commons", npmCachePackageKey("@example-commons/foo"), "foo-1.2.0.tgz")); err != nil {
+		t.Fatalf("expected rewrite cache artifact in isolated namespace: %v", err)
 	}
 }
 

--- a/npm_gitlab_e2e_test.go
+++ b/npm_gitlab_e2e_test.go
@@ -19,10 +19,11 @@ import (
 )
 
 type fakeGitLabRepo struct {
-	Tags        []string
-	TagTargets  map[string]string
-	Archives    map[string]map[string]string
-	ArchiveHits *atomic.Int32
+	Tags          []string
+	TagTargets    map[string]string
+	Archives      map[string]map[string]string
+	ArchiveHits   *atomic.Int32
+	AllowedTokens map[string]bool
 }
 
 type fakeGitLabRegistry struct {
@@ -34,6 +35,25 @@ func newFakeGitLabRegistry(t *testing.T, repos map[string]fakeGitLabRepo) *fakeG
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
 		trimmed := strings.TrimPrefix(r.URL.Path, "/api/v4/projects/")
+		if !strings.Contains(trimmed, "/repository/") {
+			projectPath, err := url.PathUnescape(strings.Trim(trimmed, "/"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			repo, ok := repos[projectPath]
+			if !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			if !fakeGitLabTokenAllowed(repo, r) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"path_with_namespace":"`+projectPath+`"}`)
+			return
+		}
 		if strings.HasSuffix(trimmed, "/repository/tags") {
 			projectPath, err := url.PathUnescape(strings.TrimSuffix(trimmed, "/repository/tags"))
 			if err != nil {
@@ -43,6 +63,10 @@ func newFakeGitLabRegistry(t *testing.T, repos map[string]fakeGitLabRepo) *fakeG
 			repo, ok := repos[projectPath]
 			if !ok {
 				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			if !fakeGitLabTokenAllowed(repo, r) {
+				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
 			payload := make([]map[string]string, 0, len(repo.Tags))
@@ -66,6 +90,10 @@ func newFakeGitLabRegistry(t *testing.T, repos map[string]fakeGitLabRepo) *fakeG
 			repo, ok := repos[projectPath]
 			if !ok {
 				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			if !fakeGitLabTokenAllowed(repo, r) {
+				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
 			tag := r.URL.Query().Get("sha")
@@ -93,6 +121,21 @@ func newFakeGitLabRegistry(t *testing.T, repos map[string]fakeGitLabRepo) *fakeG
 
 func (f *fakeGitLabRegistry) Close()       { f.server.Close() }
 func (f *fakeGitLabRegistry) Host() string { return strings.TrimPrefix(f.server.URL, "http://") }
+
+func fakeGitLabTokenAllowed(repo fakeGitLabRepo, r *http.Request) bool {
+	if len(repo.AllowedTokens) == 0 {
+		return true
+	}
+	if token := strings.TrimSpace(r.Header.Get("PRIVATE-TOKEN")); token != "" {
+		return repo.AllowedTokens[token]
+	}
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+		token := strings.TrimSpace(auth[len("Bearer "):])
+		return repo.AllowedTokens[token]
+	}
+	return false
+}
 
 func readNPMTarballFiles(body []byte) (map[string]string, error) {
 	gz, err := gzip.NewReader(bytes.NewReader(body))
@@ -143,6 +186,166 @@ func makeGitLabArchive(root string, files map[string]string) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func TestNPMRewriteMetadataUsesGitLabTokenAgainstDerivedRepoPath(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"platform/commons/foo": {
+			Tags: []string{"v1.0.0"},
+			Archives: map[string]map[string]string{
+				"v1.0.0": {"package.json": `{"name":"@example-commons/foo"}`},
+			},
+			AllowedTokens: map[string]bool{"good-token": true},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "gitlab"
+type = "gitlab_access_token"
+options.root_url = "http://%s"
+options.project_prefix = "wrong/prefix"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "platform/commons"
+auth_module = "gitlab"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), gitlab.Host(), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo", npmPort), nil)
+	req.SetBasicAuth("gitlab", "good-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request derived-repo metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200", resp.StatusCode, string(body))
+	}
+}
+
+func TestNPMRewriteMetadataRejectsGitLabTokenWithoutDerivedRepoAccess(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"platform/commons/foo": {
+			Tags: []string{"v1.0.0"},
+			Archives: map[string]map[string]string{
+				"v1.0.0": {"package.json": `{"name":"@example-commons/foo"}`},
+			},
+			AllowedTokens: map[string]bool{"good-token": true},
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "gitlab"
+type = "gitlab_access_token"
+options.root_url = "http://%s"
+options.project_prefix = "wrong/prefix"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "platform/commons"
+auth_module = "gitlab"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), gitlab.Host(), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo", npmPort), nil)
+	req.SetBasicAuth("gitlab", "bad-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request derived-repo metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%q, want 403", resp.StatusCode, string(body))
+	}
 }
 
 func TestNPMRewriteMetadataSynthesizesFromGitLabTags(t *testing.T) {

--- a/npm_gitlab_e2e_test.go
+++ b/npm_gitlab_e2e_test.go
@@ -70,13 +70,36 @@ func newFakeGitLabRegistry(t *testing.T, repos map[string]fakeGitLabRepo) *fakeG
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
-			payload := make([]map[string]string, 0, len(repo.Tags))
-			for _, tag := range repo.Tags {
+			page := 1
+			if raw := strings.TrimSpace(r.URL.Query().Get("page")); raw != "" {
+				if _, err := fmt.Sscanf(raw, "%d", &page); err != nil || page < 1 {
+					page = 1
+				}
+			}
+			perPage := 20
+			if raw := strings.TrimSpace(r.URL.Query().Get("per_page")); raw != "" {
+				if _, err := fmt.Sscanf(raw, "%d", &perPage); err != nil || perPage < 1 {
+					perPage = 20
+				}
+			}
+			start := (page - 1) * perPage
+			if start > len(repo.Tags) {
+				start = len(repo.Tags)
+			}
+			end := start + perPage
+			if end > len(repo.Tags) {
+				end = len(repo.Tags)
+			}
+			payload := make([]map[string]string, 0, end-start)
+			for _, tag := range repo.Tags[start:end] {
 				entry := map[string]string{"name": tag}
 				if target := repo.TagTargets[tag]; target != "" {
 					entry["target"] = target
 				}
 				payload = append(payload, entry)
+			}
+			if end < len(repo.Tags) {
+				w.Header().Set("X-Next-Page", fmt.Sprintf("%d", page+1))
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(payload)
@@ -451,6 +474,102 @@ auth_module = "static"
 	wantTarball := fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo/-/foo-1.3.0.tgz", npmPort)
 	if dist["tarball"] != wantTarball {
 		t.Fatalf("tarball=%v, want %q", dist["tarball"], wantTarball)
+	}
+}
+
+func TestNPMRewriteMetadataPaginatesGitLabTags(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	tags := make([]string, 0, 25)
+	archives := make(map[string]map[string]string, 25)
+	for i := 25; i >= 1; i-- {
+		tag := fmt.Sprintf("v1.0.%d", i)
+		tags = append(tags, tag)
+		archives[tag] = map[string]string{
+			"package.json": fmt.Sprintf(`{"name":"@example-commons/foo","version":"1.0.%d"}`, i),
+		}
+	}
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{
+		"commons/foo": {
+			Tags:     tags,
+			Archives: archives,
+		},
+	})
+	defer gitlab.Close()
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = %q
+target_group = "commons"
+auth_module = "static"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort, gitlab.Host())
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/%%40example-commons%%2Ffoo", npmPort), nil)
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request rewritten metadata: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200", resp.StatusCode, string(body))
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	versions := doc["versions"].(map[string]any)
+	if len(versions) != 25 {
+		t.Fatalf("versions len=%d, want 25", len(versions))
+	}
+	if _, ok := versions["1.0.1"]; !ok {
+		t.Fatalf("expected paginated older version 1.0.1 to be present")
 	}
 }
 

--- a/npm_rewrite.go
+++ b/npm_rewrite.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+type NPMRewriteRule struct {
+	Scope       string `koanf:"scope"`
+	TargetHost  string `koanf:"target_host"`
+	TargetGroup string `koanf:"target_group"`
+	AuthModule  string `koanf:"auth_module"`
+}
+
+func matchNPMRewriteRule(rules []NPMRewriteRule, pkg string) (NPMRewriteRule, bool) {
+	for _, rule := range rules {
+		if pkg == rule.Scope || strings.HasPrefix(pkg, rule.Scope+"/") {
+			return rule, true
+		}
+	}
+	return NPMRewriteRule{}, false
+}
+
+func repoPathForPackage(rule NPMRewriteRule, pkg string) (string, error) {
+	if pkg != rule.Scope && !strings.HasPrefix(pkg, rule.Scope+"/") {
+		return "", fmt.Errorf("package %q does not match rewrite scope %q", pkg, rule.Scope)
+	}
+	name := strings.TrimPrefix(pkg, rule.Scope)
+	name = strings.TrimPrefix(name, "/")
+	if name == "" || strings.Contains(name, "/") || !isValidPackageSegment(name) {
+		return "", fmt.Errorf("invalid rewritten npm package path %q", pkg)
+	}
+	group := normalizeTargetGroup(rule.TargetGroup)
+	if group == "" {
+		return "", fmt.Errorf("rewrite rule target_group is empty")
+	}
+	return group + "/" + name, nil
+}
+
+func validateNPMRewriteRules(npmCfg NPMProtocolConfig) error {
+	seenScopes := map[string]struct{}{}
+	protectedScopes := map[string]struct{}{}
+	for _, rule := range npmCfg.ProtectedScopes {
+		protectedScopes[strings.TrimSpace(rule.Scope)] = struct{}{}
+	}
+	for _, rule := range npmCfg.RewriteRules {
+		scope := strings.TrimSpace(rule.Scope)
+		if !isValidNPMScope(scope) {
+			return fmt.Errorf("invalid npm rewrite scope %q", rule.Scope)
+		}
+		if _, ok := seenScopes[scope]; ok {
+			return fmt.Errorf("duplicate npm rewrite scope %q", scope)
+		}
+		seenScopes[scope] = struct{}{}
+		if _, ok := protectedScopes[scope]; ok {
+			return fmt.Errorf("npm rewrite scope %q conflicts with protected scope; rewrite rules have their own auth_module", scope)
+		}
+		if !isValidRewriteTargetHost(rule.TargetHost) {
+			return fmt.Errorf("npm rewrite scope %q has invalid target_host %q", scope, rule.TargetHost)
+		}
+		if strings.TrimSpace(rule.AuthModule) == "" {
+			return fmt.Errorf("npm rewrite scope %q must declare auth_module", scope)
+		}
+		if !isValidTargetGroup(rule.TargetGroup) {
+			return fmt.Errorf("npm rewrite scope %q has invalid target_group %q", scope, rule.TargetGroup)
+		}
+	}
+	return nil
+}
+
+func isValidNPMScope(scope string) bool {
+	if !strings.HasPrefix(scope, "@") {
+		return false
+	}
+	name := strings.TrimPrefix(scope, "@")
+	if name == "" || strings.Contains(name, "/") {
+		return false
+	}
+	return isValidPackageSegment(name)
+}
+
+func isValidTargetGroup(group string) bool {
+	group = normalizeTargetGroup(group)
+	if group == "" {
+		return false
+	}
+	parts := strings.Split(group, "/")
+	for _, part := range parts {
+		if !isValidPackageSegment(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeTargetGroup(group string) string {
+	return strings.Trim(strings.TrimSpace(group), "/")
+}
+
+func isValidPackageSegment(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+		if i == 0 && (r == '-' || r == '_' || r == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidRewriteTargetHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" || strings.ContainsAny(host, "/?#@") {
+		return false
+	}
+	normalized := normalizeListenerHost(host)
+	if normalized == "" {
+		return false
+	}
+	if strings.Contains(host, ":") {
+		parsedHost, parsedPort, err := net.SplitHostPort(host)
+		if err != nil || parsedHost == "" || parsedPort == "" {
+			return false
+		}
+		normalized = parsedHost
+	}
+	return normalized != "" && !strings.ContainsAny(normalized, "/?#@")
+}

--- a/npm_rewrite_test.go
+++ b/npm_rewrite_test.go
@@ -1,0 +1,175 @@
+package main
+
+import "testing"
+
+func TestMatchNPMRewriteRule(t *testing.T) {
+	rule, ok := matchNPMRewriteRule([]NPMRewriteRule{{Scope: "@example-commons"}}, "@example-commons/foo")
+	if !ok {
+		t.Fatalf("expected rewrite rule match")
+	}
+	if rule.Scope != "@example-commons" {
+		t.Fatalf("matched scope = %q, want %q", rule.Scope, "@example-commons")
+	}
+}
+
+func TestRepoPathForPackage(t *testing.T) {
+	repoPath, err := repoPathForPackage(NPMRewriteRule{
+		Scope:       "@example-commons",
+		TargetHost:  "gitlab.example.com",
+		TargetGroup: "commons",
+		AuthModule:  "gitlab",
+	}, "@example-commons/foo")
+	if err != nil {
+		t.Fatalf("repoPathForPackage() error = %v", err)
+	}
+	if repoPath != "commons/foo" {
+		t.Fatalf("repoPathForPackage() = %q, want %q", repoPath, "commons/foo")
+	}
+}
+
+func TestRepoPathForPackageSupportsSubgroups(t *testing.T) {
+	repoPath, err := repoPathForPackage(NPMRewriteRule{
+		Scope:       "@example-platform",
+		TargetHost:  "gitlab.example.com",
+		TargetGroup: "platform/commons",
+		AuthModule:  "gitlab",
+	}, "@example-platform/foo")
+	if err != nil {
+		t.Fatalf("repoPathForPackage() error = %v", err)
+	}
+	if repoPath != "platform/commons/foo" {
+		t.Fatalf("repoPathForPackage() = %q, want %q", repoPath, "platform/commons/foo")
+	}
+}
+
+func TestRepoPathForPackageRejectsNestedPackageName(t *testing.T) {
+	_, err := repoPathForPackage(NPMRewriteRule{
+		Scope:       "@example-commons",
+		TargetHost:  "gitlab.example.com",
+		TargetGroup: "commons",
+		AuthModule:  "gitlab",
+	}, "@example-commons/foo/bar")
+	if err == nil {
+		t.Fatalf("expected nested package name to be rejected")
+	}
+}
+
+func TestRepoPathForPackageRejectsDotSegmentName(t *testing.T) {
+	for _, pkg := range []string{"@example-commons/..", "@example-commons/.foo"} {
+		t.Run(pkg, func(t *testing.T) {
+			_, err := repoPathForPackage(NPMRewriteRule{
+				Scope:       "@example-commons",
+				TargetHost:  "gitlab.example.com",
+				TargetGroup: "commons",
+				AuthModule:  "gitlab",
+			}, pkg)
+			if err == nil {
+				t.Fatalf("expected invalid rewritten package name %q to be rejected", pkg)
+			}
+		})
+	}
+}
+
+func TestValidateNPMRewriteRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     NPMProtocolConfig
+		wantErr bool
+	}{
+		{
+			name: "valid rewrite rule",
+			cfg: NPMProtocolConfig{RewriteRules: []NPMRewriteRule{{
+				Scope:       "@example-commons",
+				TargetHost:  "gitlab.example.com",
+				TargetGroup: "commons",
+				AuthModule:  "gitlab",
+			}}},
+		},
+		{
+			name: "duplicate rewrite scope",
+			cfg: NPMProtocolConfig{RewriteRules: []NPMRewriteRule{{
+				Scope:       "@example-commons",
+				TargetHost:  "gitlab.example.com",
+				TargetGroup: "commons",
+				AuthModule:  "gitlab",
+			}, {
+				Scope:       "@example-commons",
+				TargetHost:  "gitlab.example.com",
+				TargetGroup: "commons-alt",
+				AuthModule:  "gitlab",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "invalid scope format",
+			cfg: NPMProtocolConfig{RewriteRules: []NPMRewriteRule{{
+				Scope:       "example-commons",
+				TargetHost:  "gitlab.example.com",
+				TargetGroup: "commons",
+				AuthModule:  "gitlab",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "missing auth module",
+			cfg: NPMProtocolConfig{RewriteRules: []NPMRewriteRule{{
+				Scope:       "@example-commons",
+				TargetHost:  "gitlab.example.com",
+				TargetGroup: "commons",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "invalid target host with userinfo",
+			cfg: NPMProtocolConfig{RewriteRules: []NPMRewriteRule{{
+				Scope:       "@example-commons",
+				TargetHost:  "user@gitlab.example.com",
+				TargetGroup: "commons",
+				AuthModule:  "gitlab",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "invalid target host with query",
+			cfg: NPMProtocolConfig{RewriteRules: []NPMRewriteRule{{
+				Scope:       "@example-commons",
+				TargetHost:  "gitlab.example.com?x=1",
+				TargetGroup: "commons",
+				AuthModule:  "gitlab",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "invalid target group",
+			cfg: NPMProtocolConfig{RewriteRules: []NPMRewriteRule{{
+				Scope:       "@example-commons",
+				TargetHost:  "gitlab.example.com",
+				TargetGroup: "../commons",
+				AuthModule:  "gitlab",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "protected scope conflict",
+			cfg: NPMProtocolConfig{
+				ProtectedScopes: []ProtectedScopeRule{{Scope: "@example-commons", AuthModule: "gitlab"}},
+				RewriteRules: []NPMRewriteRule{{
+					Scope:       "@example-commons",
+					TargetHost:  "gitlab.example.com",
+					TargetGroup: "commons",
+					AuthModule:  "gitlab",
+				}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNPMRewriteRules(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateNPMRewriteRules() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/npm_synth.go
+++ b/npm_synth.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
+	"path"
 	"strings"
 )
 
@@ -56,4 +61,92 @@ func synthesizeNPMRewriteMetadata(pkg, baseURL string, versions []gitLabPackageV
 func rewrittenTarballFilename(pkg, version string) string {
 	parts := strings.Split(pkg, "/")
 	return parts[len(parts)-1] + "-" + version + ".tgz"
+}
+
+func rewrittenTarballVersion(pkg, filename string) (string, error) {
+	expectedPrefix := strings.TrimSuffix(rewrittenTarballFilename(pkg, "0"), "0.tgz")
+	if !strings.HasPrefix(filename, expectedPrefix) || !strings.HasSuffix(filename, ".tgz") {
+		return "", fmt.Errorf("filename %q does not match rewritten package %q", filename, pkg)
+	}
+	version := strings.TrimSuffix(strings.TrimPrefix(filename, expectedPrefix), ".tgz")
+	if version == "" {
+		return "", fmt.Errorf("missing version in tarball filename %q", filename)
+	}
+	return version, nil
+}
+
+func synthesizeNPMTarballFromGitLabArchive(pkg string, body []byte) ([]byte, error) {
+	gzReader, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer gzReader.Close()
+
+	tr := tar.NewReader(gzReader)
+	var out bytes.Buffer
+	gzWriter := gzip.NewWriter(&out)
+	tw := tar.NewWriter(gzWriter)
+	foundPackageJSON := false
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		clean := path.Clean(hdr.Name)
+		parts := strings.Split(clean, "/")
+		if len(parts) < 2 {
+			continue
+		}
+		relPath := path.Join(parts[1:]...)
+		if relPath == "." || relPath == "" {
+			continue
+		}
+		newHdr := *hdr
+		newHdr.Name = path.Join("package", relPath)
+		if relPath == "package.json" && (hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA) {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, err
+			}
+			var manifest map[string]any
+			if err := json.Unmarshal(data, &manifest); err != nil {
+				return nil, err
+			}
+			name, _ := manifest["name"].(string)
+			if name != pkg {
+				return nil, fmt.Errorf("package.json name mismatch in tarball source: got %q want %q", name, pkg)
+			}
+			foundPackageJSON = true
+			newHdr.Size = int64(len(data))
+			if err := tw.WriteHeader(&newHdr); err != nil {
+				return nil, err
+			}
+			if _, err := tw.Write(data); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if err := tw.WriteHeader(&newHdr); err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {
+			if _, err := io.Copy(tw, tr); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if !foundPackageJSON {
+		return nil, fmt.Errorf("root package.json not found in archive")
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gzWriter.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
 }

--- a/npm_synth.go
+++ b/npm_synth.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+var allowedManifestFields = []string{
+	"dependencies",
+	"peerDependencies",
+	"optionalDependencies",
+	"bin",
+	"engines",
+	"type",
+	"main",
+	"module",
+	"types",
+	"exports",
+}
+
+func synthesizeNPMRewriteMetadata(pkg, baseURL string, versions []gitLabPackageVersion) ([]byte, int, error) {
+	if len(versions) == 0 {
+		return nil, 0, fmt.Errorf("no versions available")
+	}
+	doc := map[string]any{
+		"name": pkg,
+		"dist-tags": map[string]any{
+			"latest": versions[0].Version,
+		},
+		"versions": map[string]any{},
+	}
+	versionsMap := doc["versions"].(map[string]any)
+	for _, version := range versions {
+		entry := map[string]any{
+			"name":    pkg,
+			"version": version.Version,
+			"dist": map[string]any{
+				"tarball": fmt.Sprintf("%s/%s/-/%s", strings.TrimSuffix(baseURL, "/"), encodeNPMPackagePath(pkg), rewrittenTarballFilename(pkg, version.Version)),
+			},
+		}
+		for _, field := range allowedManifestFields {
+			if value, ok := version.Manifest[field]; ok {
+				entry[field] = value
+			}
+		}
+		versionsMap[version.Version] = entry
+	}
+	body, err := json.Marshal(doc)
+	if err != nil {
+		return nil, 0, err
+	}
+	return body, 0, nil
+}
+
+func rewrittenTarballFilename(pkg, version string) string {
+	parts := strings.Split(pkg, "/")
+	return parts[len(parts)-1] + "-" + version + ".tgz"
+}

--- a/npm_test.go
+++ b/npm_test.go
@@ -61,7 +61,7 @@ func TestNPMScopedMetadataRequestReturnsRewrittenTarballs(t *testing.T) {
 			if resp.StatusCode != http.StatusOK {
 				t.Fatalf("status=%d body=%q, want 200", resp.StatusCode, body)
 			}
-			want := "http://127.0.0.1:" + strconv.Itoa(npmPort) + "/@toru/fixture-scoped/-/fixture-scoped-1.0.0.tgz"
+			want := "http://127.0.0.1:" + strconv.Itoa(npmPort) + "/%40toru%2Ffixture-scoped/-/fixture-scoped-1.0.0.tgz"
 			if !strings.Contains(body, want) {
 				t.Fatalf("rewritten scoped tarball URL missing: want substring %q in %q", want, body)
 			}

--- a/npm_test.go
+++ b/npm_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -81,6 +82,8 @@ func TestNPMRewriteRuleTakesPrecedenceOverUpstreamMetadata(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)
 	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{})
+	defer gitlab.Close()
 
 	cfgText := `[server]
 address = ":` + strconv.Itoa(goPort) + `"
@@ -105,6 +108,14 @@ mutable_metadata_ttl = "0s"
 [cache.disk]
 path = "/tmp/toru-cache"
 
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
 [protocols.go]
 enabled = true
 fetch_timeout = "30s"
@@ -117,23 +128,30 @@ base_url = "http://127.0.0.1:` + strconv.Itoa(npmPort) + `"
 
 [[protocols.npm.rewrite_rules]]
 scope = "@example-commons"
-target_host = "gitlab.example.com"
+target_host = "` + gitlab.Host() + `"
 target_group = "commons"
-auth_module = "gitlab"
+auth_module = "static"
 `
 	proc := startToruProcess(t, cfgText)
 	defer stopCmd(t, proc)
 
 	waitForHTTP200(t, "http://127.0.0.1:"+strconv.Itoa(goPort)+"/metrics", 10*time.Second)
 
-	resp, body, err := getURL("http://127.0.0.1:" + strconv.Itoa(npmPort) + "/%40example-commons%2Ffoo")
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:"+strconv.Itoa(npmPort)+"/%40example-commons%2Ffoo", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request rewritten npm metadata: %v", err)
 	}
 	defer resp.Body.Close()
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	body := string(bodyBytes)
 
-	if resp.StatusCode != http.StatusNotImplemented {
-		t.Fatalf("status=%d body=%q, want 501 so rewrite rule wins over upstream", resp.StatusCode, body)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d body=%q, want 404 from rewrite resolution so upstream is not consulted", resp.StatusCode, body)
 	}
 }
 
@@ -141,6 +159,8 @@ func TestNPMRewriteRuleRejectsInvalidLeafNameBeforeUpstream(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)
 	upstream := newFakeNPMRegistry(t)
+	gitlab := newFakeGitLabRegistry(t, map[string]fakeGitLabRepo{})
+	defer gitlab.Close()
 
 	cfgText := `[server]
 address = ":` + strconv.Itoa(goPort) + `"
@@ -165,6 +185,14 @@ mutable_metadata_ttl = "0s"
 [cache.disk]
 path = "/tmp/toru-cache"
 
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+
 [protocols.go]
 enabled = true
 fetch_timeout = "30s"
@@ -177,20 +205,27 @@ base_url = "http://127.0.0.1:` + strconv.Itoa(npmPort) + `"
 
 [[protocols.npm.rewrite_rules]]
 scope = "@example-commons"
-target_host = "gitlab.example.com"
+target_host = "` + gitlab.Host() + `"
 target_group = "commons"
-auth_module = "gitlab"
+auth_module = "static"
 `
 	proc := startToruProcess(t, cfgText)
 	defer stopCmd(t, proc)
 
 	waitForHTTP200(t, "http://127.0.0.1:"+strconv.Itoa(goPort)+"/metrics", 10*time.Second)
 
-	resp, body, err := getURL("http://127.0.0.1:" + strconv.Itoa(npmPort) + "/%40example-commons%2F..")
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:"+strconv.Itoa(npmPort)+"/%40example-commons%2F..", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.SetBasicAuth("static", "secret")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request invalid rewritten npm metadata: %v", err)
 	}
 	defer resp.Body.Close()
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	body := string(bodyBytes)
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status=%d body=%q, want 400 for invalid rewritten package leaf", resp.StatusCode, body)

--- a/npm_test.go
+++ b/npm_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Verification contract:
+// npm mode must support pnpm install-path reads for unscoped and scoped
+// packages, rewrite dist.tarball URLs back to Toru, and reject unsupported
+// mutation endpoints explicitly.
+
+func TestNPMMetadataRequestReturnsRewrittenTarballs(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := testMixedModeConfig(t, goPort, npmPort, upstream.URL)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, "http://127.0.0.1:"+strconv.Itoa(goPort)+"/metrics", 10*time.Second)
+
+	resp, body, err := getURL("http://127.0.0.1:" + strconv.Itoa(npmPort) + "/toru-fixture-pkg")
+	if err != nil {
+		t.Fatalf("request npm metadata: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%q, want 200", resp.StatusCode, body)
+	}
+	want := "http://127.0.0.1:" + strconv.Itoa(npmPort) + "/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz"
+	if !strings.Contains(body, want) {
+		t.Fatalf("rewritten tarball URL missing: want substring %q in %q", want, body)
+	}
+}
+
+func TestNPMScopedMetadataRequestReturnsRewrittenTarballs(t *testing.T) {
+	for _, scopedPath := range []string{"/@toru/fixture-scoped", "/%40toru%2Ffixture-scoped", "/@toru%2ffixture-scoped"} {
+		t.Run(scopedPath, func(t *testing.T) {
+			goPort := freePort(t)
+			npmPort := freePort(t)
+			upstream := newFakeNPMRegistry(t)
+
+			cfgText := testMixedModeConfig(t, goPort, npmPort, upstream.URL)
+			proc := startToruProcess(t, cfgText)
+			defer stopCmd(t, proc)
+
+			waitForHTTP200(t, "http://127.0.0.1:"+strconv.Itoa(goPort)+"/metrics", 10*time.Second)
+
+			resp, body, err := getURL("http://127.0.0.1:" + strconv.Itoa(npmPort) + scopedPath)
+			if err != nil {
+				t.Fatalf("request scoped npm metadata: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%q, want 200", resp.StatusCode, body)
+			}
+			want := "http://127.0.0.1:" + strconv.Itoa(npmPort) + "/@toru/fixture-scoped/-/fixture-scoped-1.0.0.tgz"
+			if !strings.Contains(body, want) {
+				t.Fatalf("rewritten scoped tarball URL missing: want substring %q in %q", want, body)
+			}
+		})
+	}
+}
+
+func TestUnsupportedNPMMutationEndpointRejected(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := testMixedModeConfig(t, goPort, npmPort, upstream.URL)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, "http://127.0.0.1:"+strconv.Itoa(goPort)+"/metrics", 10*time.Second)
+
+	req, err := http.NewRequest(http.MethodPut, "http://127.0.0.1:"+strconv.Itoa(npmPort)+"/toru-fixture-pkg", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("put request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed && resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("npm mutation status=%d, want 405 or 501", resp.StatusCode)
+	}
+}

--- a/npm_test.go
+++ b/npm_test.go
@@ -77,6 +77,126 @@ func TestNPMCachePackageKeyAvoidsScopedCollisions(t *testing.T) {
 	}
 }
 
+func TestNPMRewriteRuleTakesPrecedenceOverUpstreamMetadata(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := `[server]
+address = ":` + strconv.Itoa(goPort) + `"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":` + strconv.Itoa(goPort) + `"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":` + strconv.Itoa(npmPort) + `"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = "/tmp/toru-cache"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = "` + upstream.URL + `"
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:` + strconv.Itoa(npmPort) + `"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = "gitlab.example.com"
+target_group = "commons"
+auth_module = "gitlab"
+`
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, "http://127.0.0.1:"+strconv.Itoa(goPort)+"/metrics", 10*time.Second)
+
+	resp, body, err := getURL("http://127.0.0.1:" + strconv.Itoa(npmPort) + "/%40example-commons%2Ffoo")
+	if err != nil {
+		t.Fatalf("request rewritten npm metadata: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("status=%d body=%q, want 501 so rewrite rule wins over upstream", resp.StatusCode, body)
+	}
+}
+
+func TestNPMRewriteRuleRejectsInvalidLeafNameBeforeUpstream(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := `[server]
+address = ":` + strconv.Itoa(goPort) + `"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":` + strconv.Itoa(goPort) + `"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":` + strconv.Itoa(npmPort) + `"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = "/tmp/toru-cache"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = "` + upstream.URL + `"
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:` + strconv.Itoa(npmPort) + `"
+
+[[protocols.npm.rewrite_rules]]
+scope = "@example-commons"
+target_host = "gitlab.example.com"
+target_group = "commons"
+auth_module = "gitlab"
+`
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, "http://127.0.0.1:"+strconv.Itoa(goPort)+"/metrics", 10*time.Second)
+
+	resp, body, err := getURL("http://127.0.0.1:" + strconv.Itoa(npmPort) + "/%40example-commons%2F..")
+	if err != nil {
+		t.Fatalf("request invalid rewritten npm metadata: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%q, want 400 for invalid rewritten package leaf", resp.StatusCode, body)
+	}
+}
+
 func TestUnsupportedNPMMutationEndpointRejected(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)

--- a/npm_test.go
+++ b/npm_test.go
@@ -69,6 +69,14 @@ func TestNPMScopedMetadataRequestReturnsRewrittenTarballs(t *testing.T) {
 	}
 }
 
+func TestNPMCachePackageKeyAvoidsScopedCollisions(t *testing.T) {
+	keyA := npmCachePackageKey("@a/b__c")
+	keyB := npmCachePackageKey("@a__b/c")
+	if keyA == keyB {
+		t.Fatalf("cache keys must not collide: %q == %q", keyA, keyB)
+	}
+}
+
 func TestUnsupportedNPMMutationEndpointRejected(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)

--- a/proxy.go
+++ b/proxy.go
@@ -91,12 +91,17 @@ func newProxy(cfg *Config, logger *slog.Logger) (*Proxy, error) {
 	}, nil
 }
 
-
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	requestsTotal.Inc()
 	startTime := time.Now()
+	// Wrap the ResponseWriter immediately so early auth/error returns are counted too.
+	rw := &responseWriter{ResponseWriter: w}
+	defer func() {
+		recordProtocolRequest("go", "proxy", time.Since(startTime), rw.size)
+	}()
 
 	p.logger.Info("Received request",
+		"protocol", "go",
+		"kind", "proxy",
 		"method", r.Method,
 		"path", r.URL.Path,
 		"remote_addr", r.RemoteAddr,
@@ -105,21 +110,15 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.cfg.Auth.Enabled {
 		authMethod, _, ok := r.BasicAuth()
 		if !ok {
-			http.Error(w, "No username or password provided", http.StatusUnauthorized)
+			http.Error(rw, "No username or password provided", http.StatusUnauthorized)
 			return
 		}
-		if !authorizeRequest(w, r, p.authenticators, authMethod, AuthRequest{Protocol: "go", Path: r.URL.Path, Resource: r.URL.Path}) {
+		if !authorizeRequest(rw, r, p.authenticators, authMethod, AuthRequest{Protocol: "go", Path: r.URL.Path, Resource: r.URL.Path}) {
 			return
 		}
 	}
 
-	// Wrap the ResponseWriter to capture the response size
-	rw := &responseWriter{ResponseWriter: w}
-
 	p.client.ServeHTTP(rw, r)
-
-	requestDuration.UpdateDuration(startTime)
-	responseSize.Update(float64(rw.size))
 }
 
 // responseWriter wraps http.ResponseWriter to capture the response size

--- a/proxy.go
+++ b/proxy.go
@@ -77,15 +77,9 @@ func newProxy(cfg *Config, logger *slog.Logger) (*Proxy, error) {
 		},
 	}
 
-	authenticators := make(map[string]Authenticator)
-	if cfg.Auth.Enabled {
-		for _, module := range cfg.Auth.Modules {
-			auth, err := NewAuthenticator(module)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create authenticator: %w", err)
-			}
-			authenticators[module.Name] = auth
-		}
+	authenticators, err := buildAuthenticators(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Proxy{
@@ -109,34 +103,12 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if p.cfg.Auth.Enabled {
-		// Extract credentials from the request
-		authMethod, password, ok := r.BasicAuth()
+		authMethod, _, ok := r.BasicAuth()
 		if !ok {
 			http.Error(w, "No username or password provided", http.StatusUnauthorized)
 			return
 		}
-
-		// Check if the module is enabled
-		auth, ok := p.authenticators[authMethod]
-		if !ok {
-			http.Error(w, "Invalid auth method", http.StatusBadRequest)
-			return
-		}
-
-		// Check if the credentials are valid
-		skip, hasAccess, err := auth.Authenticate(password, r.URL.Path)
-		if err != nil {
-			p.logger.Error("Failed to authenticate", "error", err)
-			if err == ErrorAuthFailed {
-				http.Error(w, "Unauthorized: Invalid access token or insufficient permissions for the GitLab project", http.StatusForbidden)
-				return
-			}
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
-
-		if !hasAccess && !skip {
-			http.Error(w, "Unauthorized: Invalid access token or insufficient permissions for the GitLab project", http.StatusForbidden)
+		if !authorizeRequest(w, r, p.authenticators, authMethod, AuthRequest{Protocol: "go", Path: r.URL.Path, Resource: r.URL.Path}) {
 			return
 		}
 	}

--- a/runtime.go
+++ b/runtime.go
@@ -30,7 +30,10 @@ func buildListeners(cfg *Config, logger *slog.Logger) ([]runtimeServer, error) {
 	}
 
 	servers := make([]runtimeServer, 0, len(cfg.Listeners))
-	npmHandler := newNPMHandler(cfg, logger, authenticators)
+	npmHandler, err := newNPMHandler(cfg, logger, authenticators)
+	if err != nil {
+		return nil, err
+	}
 	for _, listener := range cfg.Listeners {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {

--- a/runtime.go
+++ b/runtime.go
@@ -26,20 +26,22 @@ func buildListeners(cfg *Config, logger *slog.Logger) ([]runtimeServer, error) {
 
 	servers := make([]runtimeServer, 0, len(cfg.Listeners))
 	for _, listener := range cfg.Listeners {
+		if len(listener.Protocols) != 1 {
+			return nil, fmt.Errorf("listener %q must declare exactly one protocol until host dispatch is implemented", listener.Name)
+		}
+
 		mux := http.NewServeMux()
 		mux.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 			metrics.WritePrometheus(w, true)
 		})
 
-		for _, protocol := range listener.Protocols {
-			switch protocol {
-			case "go":
-				mux.Handle("/", goProxy)
-			case "npm":
-				mux.Handle("/", newNPMHandler(cfg, logger))
-			default:
-				return nil, fmt.Errorf("unsupported protocol: %s", protocol)
-			}
+		switch listener.Protocols[0] {
+		case "go":
+			mux.Handle("/", goProxy)
+		case "npm":
+			mux.Handle("/", newNPMHandler(cfg, logger))
+		default:
+			return nil, fmt.Errorf("unsupported protocol: %s", listener.Protocols[0])
 		}
 
 		servers = append(servers, runtimeServer{

--- a/runtime.go
+++ b/runtime.go
@@ -23,6 +23,11 @@ func buildListeners(cfg *Config, logger *slog.Logger) ([]runtimeServer, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Build a shared authenticator set for non-go handlers too.
+	authenticators, err := buildAuthenticators(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	servers := make([]runtimeServer, 0, len(cfg.Listeners))
 	for _, listener := range cfg.Listeners {
@@ -39,7 +44,7 @@ func buildListeners(cfg *Config, logger *slog.Logger) ([]runtimeServer, error) {
 		case "go":
 			mux.Handle("/", goProxy)
 		case "npm":
-			mux.Handle("/", newNPMHandler(cfg, logger))
+			mux.Handle("/", newNPMHandler(cfg, logger, authenticators))
 		default:
 			return nil, fmt.Errorf("unsupported protocol: %s", listener.Protocols[0])
 		}

--- a/runtime.go
+++ b/runtime.go
@@ -30,23 +30,36 @@ func buildListeners(cfg *Config, logger *slog.Logger) ([]runtimeServer, error) {
 	}
 
 	servers := make([]runtimeServer, 0, len(cfg.Listeners))
+	npmHandler := newNPMHandler(cfg, logger, authenticators)
 	for _, listener := range cfg.Listeners {
-		if len(listener.Protocols) != 1 {
-			return nil, fmt.Errorf("listener %q must declare exactly one protocol until host dispatch is implemented", listener.Name)
-		}
-
 		mux := http.NewServeMux()
 		mux.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 			metrics.WritePrometheus(w, true)
 		})
 
-		switch listener.Protocols[0] {
-		case "go":
-			mux.Handle("/", goProxy)
-		case "npm":
-			mux.Handle("/", newNPMHandler(cfg, logger, authenticators))
-		default:
-			return nil, fmt.Errorf("unsupported protocol: %s", listener.Protocols[0])
+		if len(listener.Protocols) == 1 {
+			handler, err := protocolHandler(listener.Protocols[0], goProxy, npmHandler)
+			if err != nil {
+				return nil, err
+			}
+			mux.Handle("/", handler)
+		} else {
+			routes := make(map[string]http.Handler, len(listener.Protocols))
+			for i, protocol := range listener.Protocols {
+				handler, err := protocolHandler(protocol, goProxy, npmHandler)
+				if err != nil {
+					return nil, err
+				}
+				routes[normalizeListenerHost(listener.Hosts[i])] = handler
+			}
+			mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				handler, ok := routes[normalizeListenerHost(req.Host)]
+				if !ok {
+					http.Error(w, "unknown host for listener", http.StatusMisdirectedRequest)
+					return
+				}
+				handler.ServeHTTP(w, req)
+			}))
 		}
 
 		servers = append(servers, runtimeServer{
@@ -59,6 +72,17 @@ func buildListeners(cfg *Config, logger *slog.Logger) ([]runtimeServer, error) {
 	}
 
 	return servers, nil
+}
+
+func protocolHandler(protocol string, goProxy, npmHandler http.Handler) (http.Handler, error) {
+	switch protocol {
+	case "go":
+		return goProxy, nil
+	case "npm":
+		return npmHandler, nil
+	default:
+		return nil, fmt.Errorf("unsupported protocol: %s", protocol)
+	}
 }
 
 func run(cfg *Config, logger *slog.Logger) error {

--- a/runtime.go
+++ b/runtime.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/VictoriaMetrics/metrics"
+)
+
+type runtimeServer struct {
+	name   string
+	server *http.Server
+}
+
+func buildListeners(cfg *Config, logger *slog.Logger) ([]runtimeServer, error) {
+	goProxy, err := newProxy(cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	servers := make([]runtimeServer, 0, len(cfg.Listeners))
+	for _, listener := range cfg.Listeners {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
+			metrics.WritePrometheus(w, true)
+		})
+
+		for _, protocol := range listener.Protocols {
+			switch protocol {
+			case "go":
+				mux.Handle("/", goProxy)
+			case "npm":
+				mux.Handle("/", newNPMHandler(cfg, logger))
+			default:
+				return nil, fmt.Errorf("unsupported protocol: %s", protocol)
+			}
+		}
+
+		servers = append(servers, runtimeServer{
+			name: listener.Name,
+			server: &http.Server{
+				Addr:    listener.Address,
+				Handler: mux,
+			},
+		})
+	}
+
+	return servers, nil
+}
+
+func run(cfg *Config, logger *slog.Logger) error {
+	servers, err := buildListeners(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	errCh := make(chan error, len(servers))
+	for _, srv := range servers {
+		srv := srv
+		go func() {
+			logger.Info("Starting listener", "name", srv.name, "address", srv.server.Addr)
+			if err := srv.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				errCh <- err
+			}
+		}()
+	}
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case <-quit:
+	case err := <-errCh:
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	for _, srv := range servers {
+		_ = srv.server.Shutdown(ctx)
+	}
+	return nil
+}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -21,6 +21,65 @@ import (
 // separate Go and npm listeners, metrics still available, and npm traffic not
 // handled by the legacy Go-only path.
 
+func TestSingleListenerHostDispatchRoutesByHost(t *testing.T) {
+	port := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "shared"
+address = ":%d"
+protocols = ["go", "npm"]
+hosts = ["toru.example.com", "npm-toru.example.com"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://npm-toru.example.com"
+`, port, port, filepath.Join(t.TempDir(), "cache"), upstream.URL)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", port), 10*time.Second)
+
+	npmResp, npmBody, err := getURLWithHost(fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", port), "npm-toru.example.com")
+	if err != nil {
+		t.Fatalf("npm host request: %v", err)
+	}
+	defer npmResp.Body.Close()
+	if npmResp.StatusCode != http.StatusOK {
+		t.Fatalf("npm host request status = %d body=%q, want 200", npmResp.StatusCode, npmBody)
+	}
+	if !strings.Contains(npmBody, "npm-toru.example.com/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz") {
+		t.Fatalf("npm host response must be served by npm handler, body=%q", npmBody)
+	}
+
+	goResp, goBody, err := getURLWithHost(fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", port), "toru.example.com")
+	if err != nil {
+		t.Fatalf("go host request: %v", err)
+	}
+	defer goResp.Body.Close()
+	if goResp.StatusCode == http.StatusOK {
+		t.Fatalf("go host request unexpectedly returned 200 body=%q; expected non-npm dispatch", goBody)
+	}
+}
+
 func TestMixedModeRuntimeExposesMetricsAndNPMListener(t *testing.T) {
 	goPort := freePort(t)
 	npmPort := freePort(t)
@@ -381,6 +440,25 @@ func waitForHTTP200(t *testing.T, rawURL string, timeout time.Duration) {
 
 func getURL(rawURL string) (*http.Response, string, error) {
 	resp, err := http.Get(rawURL)
+	if err != nil {
+		return nil, "", err
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		_ = resp.Body.Close()
+		return nil, "", readErr
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, string(body), nil
+}
+
+func getURLWithHost(rawURL, host string) (*http.Response, string, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Host = host
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, "", err
 	}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Verification contract:
+// Mixed-mode Toru must be provable through observable behavior in one process:
+// separate Go and npm listeners, metrics still available, and npm traffic not
+// handled by the legacy Go-only path.
+
+func TestMixedModeRuntimeExposesMetricsAndNPMListener(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := testMixedModeConfig(t, goPort, npmPort, upstream.URL)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	resp, body, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort))
+	if err != nil {
+		t.Fatalf("expected npm listener to accept metadata request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("npm metadata status = %d body=%q, want 200", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", npmPort)) {
+		t.Fatalf("npm metadata must rewrite tarball URL back to Toru, body=%q", body)
+	}
+}
+
+func testMixedModeConfig(t *testing.T, goPort, npmPort int, upstreamURL string) string {
+	t.Helper()
+	return fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstreamURL, npmPort)
+}
+
+func newFakeNPMRegistry(t *testing.T) *httptest.Server {
+	t.Helper()
+	return newCountingFakeNPMRegistry(t, nil)
+}
+
+func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toru-fixture-pkg", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"name":"toru-fixture-pkg",
+			"dist-tags":{"latest":"1.0.0"},
+			"versions":{
+				"1.0.0":{
+					"name":"toru-fixture-pkg",
+					"version":"1.0.0",
+					"dist":{
+						"tarball":"https://registry.npmjs.org/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz",
+						"integrity":"sha512-deadbeef"
+					}
+				}
+			}
+		}`)
+	})
+	mux.HandleFunc("/@toru/fixture-scoped", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"name":"@toru/fixture-scoped",
+			"dist-tags":{"latest":"1.0.0"},
+			"versions":{
+				"1.0.0":{
+					"name":"@toru/fixture-scoped",
+					"version":"1.0.0",
+					"dist":{
+						"tarball":"https://registry.npmjs.org/@toru/fixture-scoped/-/fixture-scoped-1.0.0.tgz",
+						"integrity":"sha512-cafebabe"
+					}
+				}
+			}
+		}`)
+	})
+	mux.HandleFunc("/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", func(w http.ResponseWriter, r *http.Request) {
+		if tarballHits != nil {
+			tarballHits.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = io.WriteString(w, "fake-tgz-unscoped")
+	})
+	mux.HandleFunc("/@toru/fixture-scoped/-/fixture-scoped-1.0.0.tgz", func(w http.ResponseWriter, r *http.Request) {
+		if tarballHits != nil {
+			tarballHits.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = io.WriteString(w, "fake-tgz-scoped")
+	})
+	return httptest.NewServer(mux)
+}
+
+func startToruProcess(t *testing.T, cfgText string) *exec.Cmd {
+	t.Helper()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(cfgText), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", "--config", cfgPath)
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(), "TORU_TEST_HELPER_PROCESS=1")
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start toru helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("toru output:\n%s", output.String())
+		}
+	})
+	return cmd
+}
+
+func stopCmd(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+	_ = cmd.Wait()
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("TORU_TEST_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	for i, arg := range args {
+		if arg == "--" {
+			os.Args = append([]string{"toru"}, args[i+1:]...)
+			main()
+			return
+		}
+	}
+
+	os.Exit(2)
+}
+
+func waitForHTTP200(t *testing.T, rawURL string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, _, err := getURL(rawURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for 200 from %s", rawURL)
+}
+
+func getURL(rawURL string) (*http.Response, string, error) {
+	resp, err := http.Get(rawURL)
+	if err != nil {
+		return nil, "", err
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		_ = resp.Body.Close()
+		return nil, "", readErr
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, string(body), nil
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("get free port: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -108,7 +108,7 @@ func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httpte
 			}
 		}`)
 	})
-	mux.HandleFunc("/@toru/fixture-scoped", func(w http.ResponseWriter, r *http.Request) {
+	scopedMetadataHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"name":"@toru/fixture-scoped",
@@ -124,7 +124,9 @@ func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httpte
 				}
 			}
 		}`)
-	})
+	}
+	mux.HandleFunc("/@toru/fixture-scoped", scopedMetadataHandler)
+	mux.HandleFunc("/%40toru%2Ffixture-scoped", scopedMetadataHandler)
 	mux.HandleFunc("/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", func(w http.ResponseWriter, r *http.Request) {
 		if tarballHits != nil {
 			tarballHits.Add(1)
@@ -132,13 +134,15 @@ func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httpte
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = io.WriteString(w, "fake-tgz-unscoped")
 	})
-	mux.HandleFunc("/@toru/fixture-scoped/-/fixture-scoped-1.0.0.tgz", func(w http.ResponseWriter, r *http.Request) {
+	scopedTarballHandler := func(w http.ResponseWriter, r *http.Request) {
 		if tarballHits != nil {
 			tarballHits.Add(1)
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = io.WriteString(w, "fake-tgz-scoped")
-	})
+	}
+	mux.HandleFunc("/@toru/fixture-scoped/-/fixture-scoped-1.0.0.tgz", scopedTarballHandler)
+	mux.HandleFunc("/%40toru%2Ffixture-scoped/-/fixture-scoped-1.0.0.tgz", scopedTarballHandler)
 	return httptest.NewServer(mux)
 }
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -85,13 +85,21 @@ base_url = "http://127.0.0.1:%d"
 
 func newFakeNPMRegistry(t *testing.T) *httptest.Server {
 	t.Helper()
-	return newCountingFakeNPMRegistry(t, nil)
+	return newCountingFakeNPMRegistryWithCounters(t, nil, nil, nil, nil)
 }
 
 func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httptest.Server {
 	t.Helper()
+	return newCountingFakeNPMRegistryWithCounters(t, nil, nil, tarballHits, tarballHits)
+}
+
+func newCountingFakeNPMRegistryWithCounters(t *testing.T, unscopedMetadataHits, scopedMetadataHits, unscopedTarballHits, scopedTarballHits *atomic.Int32) *httptest.Server {
+	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/toru-fixture-pkg", func(w http.ResponseWriter, r *http.Request) {
+		if unscopedMetadataHits != nil {
+			unscopedMetadataHits.Add(1)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"name":"toru-fixture-pkg",
@@ -109,6 +117,9 @@ func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httpte
 		}`)
 	})
 	scopedMetadataHandler := func(w http.ResponseWriter, r *http.Request) {
+		if scopedMetadataHits != nil {
+			scopedMetadataHits.Add(1)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"name":"@toru/fixture-scoped",
@@ -128,15 +139,15 @@ func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httpte
 	mux.HandleFunc("/@toru/fixture-scoped", scopedMetadataHandler)
 	mux.HandleFunc("/%40toru%2Ffixture-scoped", scopedMetadataHandler)
 	mux.HandleFunc("/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", func(w http.ResponseWriter, r *http.Request) {
-		if tarballHits != nil {
-			tarballHits.Add(1)
+		if unscopedTarballHits != nil {
+			unscopedTarballHits.Add(1)
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = io.WriteString(w, "fake-tgz-unscoped")
 	})
 	scopedTarballHandler := func(w http.ResponseWriter, r *http.Request) {
-		if tarballHits != nil {
-			tarballHits.Add(1)
+		if scopedTarballHits != nil {
+			scopedTarballHits.Add(1)
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = io.WriteString(w, "fake-tgz-scoped")

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -299,25 +299,43 @@ base_url = "http://127.0.0.1:%d"
 `, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstreamURL, npmPort)
 }
 
+type fakeNPMRegistryOptions struct {
+	UnscopedMetadataHits  *atomic.Int32
+	ScopedMetadataHits    *atomic.Int32
+	UnscopedTarballHits   *atomic.Int32
+	ScopedTarballHits     *atomic.Int32
+	MetadataETag          string
+	MetadataBody          string
+	Metadata304OnMatch    bool
+	MetadataStatusOnMatch int
+	MetadataBodyOnMatch   string
+}
+
 func newFakeNPMRegistry(t *testing.T) *httptest.Server {
 	t.Helper()
-	return newCountingFakeNPMRegistryWithCounters(t, nil, nil, nil, nil)
+	return newFakeNPMRegistryWithOptions(t, fakeNPMRegistryOptions{})
 }
 
 func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httptest.Server {
 	t.Helper()
-	return newCountingFakeNPMRegistryWithCounters(t, nil, nil, tarballHits, tarballHits)
+	return newFakeNPMRegistryWithOptions(t, fakeNPMRegistryOptions{UnscopedTarballHits: tarballHits, ScopedTarballHits: tarballHits})
 }
 
 func newCountingFakeNPMRegistryWithCounters(t *testing.T, unscopedMetadataHits, scopedMetadataHits, unscopedTarballHits, scopedTarballHits *atomic.Int32) *httptest.Server {
 	t.Helper()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/toru-fixture-pkg", func(w http.ResponseWriter, r *http.Request) {
-		if unscopedMetadataHits != nil {
-			unscopedMetadataHits.Add(1)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{
+	return newFakeNPMRegistryWithOptions(t, fakeNPMRegistryOptions{
+		UnscopedMetadataHits: unscopedMetadataHits,
+		ScopedMetadataHits:   scopedMetadataHits,
+		UnscopedTarballHits:  unscopedTarballHits,
+		ScopedTarballHits:    scopedTarballHits,
+	})
+}
+
+func newFakeNPMRegistryWithOptions(t *testing.T, opts fakeNPMRegistryOptions) *httptest.Server {
+	t.Helper()
+	metadataBody := opts.MetadataBody
+	if metadataBody == "" {
+		metadataBody = `{
 			"name":"toru-fixture-pkg",
 			"dist-tags":{"latest":"1.0.0"},
 			"versions":{
@@ -330,11 +348,35 @@ func newCountingFakeNPMRegistryWithCounters(t *testing.T, unscopedMetadataHits, 
 					}
 				}
 			}
-		}`)
+		}`
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toru-fixture-pkg", func(w http.ResponseWriter, r *http.Request) {
+		if opts.UnscopedMetadataHits != nil {
+			opts.UnscopedMetadataHits.Add(1)
+		}
+		if opts.MetadataETag != "" {
+			w.Header().Set("ETag", opts.MetadataETag)
+			if r.Header.Get("If-None-Match") == opts.MetadataETag {
+				if opts.MetadataStatusOnMatch != 0 {
+					w.WriteHeader(opts.MetadataStatusOnMatch)
+					if opts.MetadataBodyOnMatch != "" {
+						_, _ = io.WriteString(w, opts.MetadataBodyOnMatch)
+					}
+					return
+				}
+				if opts.Metadata304OnMatch {
+					w.WriteHeader(http.StatusNotModified)
+					return
+				}
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, metadataBody)
 	})
 	scopedMetadataHandler := func(w http.ResponseWriter, r *http.Request) {
-		if scopedMetadataHits != nil {
-			scopedMetadataHits.Add(1)
+		if opts.ScopedMetadataHits != nil {
+			opts.ScopedMetadataHits.Add(1)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
@@ -355,15 +397,15 @@ func newCountingFakeNPMRegistryWithCounters(t *testing.T, unscopedMetadataHits, 
 	mux.HandleFunc("/@toru/fixture-scoped", scopedMetadataHandler)
 	mux.HandleFunc("/%40toru%2Ffixture-scoped", scopedMetadataHandler)
 	mux.HandleFunc("/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", func(w http.ResponseWriter, r *http.Request) {
-		if unscopedTarballHits != nil {
-			unscopedTarballHits.Add(1)
+		if opts.UnscopedTarballHits != nil {
+			opts.UnscopedTarballHits.Add(1)
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = io.WriteString(w, "fake-tgz-unscoped")
 	})
 	scopedTarballHandler := func(w http.ResponseWriter, r *http.Request) {
-		if scopedTarballHits != nil {
-			scopedTarballHits.Add(1)
+		if opts.ScopedTarballHits != nil {
+			opts.ScopedTarballHits.Add(1)
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = io.WriteString(w, "fake-tgz-scoped")

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -142,7 +142,6 @@ func newCountingFakeNPMRegistry(t *testing.T, tarballHits *atomic.Int32) *httpte
 		_, _ = io.WriteString(w, "fake-tgz-scoped")
 	}
 	mux.HandleFunc("/@toru/fixture-scoped/-/fixture-scoped-1.0.0.tgz", scopedTarballHandler)
-	mux.HandleFunc("/%40toru%2Ffixture-scoped/-/fixture-scoped-1.0.0.tgz", scopedTarballHandler)
 	return httptest.NewServer(mux)
 }
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -44,6 +44,163 @@ func TestMixedModeRuntimeExposesMetricsAndNPMListener(t *testing.T) {
 	if !strings.Contains(body, fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg/-/toru-fixture-pkg-1.0.0.tgz", npmPort)) {
 		t.Fatalf("npm metadata must rewrite tarball URL back to Toru, body=%q", body)
 	}
+
+	_, metricsBody, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort))
+	if err != nil {
+		t.Fatalf("scrape metrics: %v", err)
+	}
+	for _, want := range []string{
+		`toru_requests_by_protocol_total{protocol="npm",kind="metadata"}`,
+		`toru_request_duration_by_protocol_seconds_count{protocol="npm",kind="metadata"}`,
+		`toru_response_size_by_protocol_bytes_count{protocol="npm",kind="metadata"}`,
+		`toru_cache_misses_by_protocol_total{protocol="npm",class="metadata"}`,
+		`toru_cache_writes_by_protocol_total{protocol="npm",class="metadata"}`,
+	} {
+		if !strings.Contains(metricsBody, want) {
+			t.Fatalf("expected metrics scrape to contain %q, body=%q", want, metricsBody)
+		}
+	}
+}
+
+func TestGoRequestMetricsCountUnauthorizedAuthRejections(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = true
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[auth]
+enabled = true
+
+[[auth.modules]]
+name = "static"
+type = "static_token"
+options.token = "secret"
+options.protected_uri = "go.example.com"
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	resp, body, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/go.example.com/team/workflows/@v/list", goPort))
+	if err != nil {
+		t.Fatalf("expected go listener to accept request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated go protected path status = %d body=%q, want 401", resp.StatusCode, body)
+	}
+
+	_, metricsBody, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort))
+	if err != nil {
+		t.Fatalf("scrape metrics: %v", err)
+	}
+	for _, want := range []string{
+		`toru_requests_total 1`,
+		`toru_requests_by_protocol_total{protocol="go",kind="proxy"} 1`,
+		`toru_request_duration_seconds_count 1`,
+		`toru_request_duration_by_protocol_seconds_count{protocol="go",kind="proxy"} 1`,
+	} {
+		if !strings.Contains(metricsBody, want) {
+			t.Fatalf("expected metrics scrape to contain %q, body=%q", want, metricsBody)
+		}
+	}
+}
+
+func TestMixedModeRuntimeDoesNotReportMetadataCacheWriteWhenMetadataCacheDisabled(t *testing.T) {
+	goPort := freePort(t)
+	npmPort := freePort(t)
+	upstream := newFakeNPMRegistry(t)
+
+	cfgText := fmt.Sprintf(`[server]
+address = ":%d"
+log_level = "info"
+fetch_timeout = "30s"
+
+[[listeners]]
+name = "go"
+address = ":%d"
+protocols = ["go"]
+
+[[listeners]]
+name = "npm"
+address = ":%d"
+protocols = ["npm"]
+
+[cache]
+enabled = false
+type = "disk"
+mutable_metadata_ttl = "0s"
+
+[cache.disk]
+path = %q
+
+[protocols.go]
+enabled = true
+fetch_timeout = "30s"
+
+[protocols.npm]
+enabled = true
+upstream = %q
+metadata_ttl = "5m"
+base_url = "http://127.0.0.1:%d"
+`, goPort, goPort, npmPort, filepath.Join(t.TempDir(), "cache"), upstream.URL, npmPort)
+	proc := startToruProcess(t, cfgText)
+	defer stopCmd(t, proc)
+
+	waitForHTTP200(t, fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort), 10*time.Second)
+
+	resp, body, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/toru-fixture-pkg", npmPort))
+	if err != nil {
+		t.Fatalf("expected npm listener to accept metadata request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("npm metadata status = %d body=%q, want 200", resp.StatusCode, body)
+	}
+
+	_, metricsBody, err := getURL(fmt.Sprintf("http://127.0.0.1:%d/metrics", goPort))
+	if err != nil {
+		t.Fatalf("scrape metrics: %v", err)
+	}
+	if strings.Contains(metricsBody, `toru_cache_writes_by_protocol_total{protocol="npm",class="metadata"}`) {
+		t.Fatalf("metrics should not report npm metadata cache writes when metadata cache is disabled, body=%q", metricsBody)
+	}
+	if !strings.Contains(metricsBody, `toru_cache_misses_by_protocol_total{protocol="npm",class="metadata"}`) {
+		t.Fatalf("expected metadata miss metric when metadata cache is disabled, body=%q", metricsBody)
+	}
 }
 
 func testMixedModeConfig(t *testing.T, goPort, npmPort int, upstreamURL string) string {


### PR DESCRIPTION
## Summary

This PR expands Toru from a Go-only proxy into a mixed Go + npm dependency proxy with support for:

- npm and pnpm read/install flows
- multi-listener runtime for Go and npm in one process
- npm metadata and tarball caching
- protected npm scopes via auth modules
- GitLab-backed npm rewrite rules for private packages without a publish step
- S3-backed npm cache storage

The branch also hardens cache correctness, auth behavior, mixed-mode routing, and operator docs.

## What changed

### Mixed-mode runtime and routing

- add mixed Go + npm listeners in the same process
- add host-based listener dispatch for shared front-proxy deployments
- expose protocol-aware metrics for npm requests and cache behavior

### Public npm/pnpm proxy support

- serve npm package metadata
- proxy npm tarballs
- rewrite `dist.tarball` URLs back to Toru
- support protected scoped packages via configured auth modules

### npm cache behavior

- add npm metadata TTL cache semantics
- support ETag revalidation for stale npm metadata
- preserve tarball availability even when cache writes fail
- support npm metadata/tarball cache storage on both disk and S3 backends
- record cache hits, misses, writes, and read/write errors with npm-specific metrics

### Private GitLab-backed npm rewrite rules

- add config primitives for npm rewrite rules
- map npm-valid package names to GitLab repos, for example:
  - `@example-commons/foo` -> `gitlab.example.com/commons/foo`
- synthesize npm metadata from GitLab tags and repo manifests
- synthesize npm tarballs from GitLab source archives with npm-compatible `package/` layout
- support both `v1.2.3` and `1.2.3` tags
- follow paginated GitLab tag listings correctly
- keep rewrite tarballs in a separate cache namespace from upstream npm tarballs

### Auth hardening

- add protocol-aware npm scope protection
- bind rewrite-backed npm authorization to the derived GitLab repo path (`RepoPath`)
- preserve existing Go auth semantics while making rewrite-backed npm auth GitLab-token driven

### Docs and samples

- update README with npm/pnpm usage, rewrite semantics, cache behavior, and v1 limits
- update `config.sample.toml` with mixed-mode, rewrite, and disk/S3 cache guidance

## Supported behavior in this PR

### Public npm registry facade

Toru can now act as a normal npm registry endpoint for install/read flows:

- `npm install`
- `pnpm add`
- metadata fetches
- tarball fetches

### Private GitLab rewrite facade

Toru can expose GitLab repos as npm packages via rewrite rules, without publishing to npm.

Example config shape:

```toml
[[protocols.npm.rewrite_rules]]
scope = "@example-commons"
target_host = "gitlab.example.com"
target_group = "commons"
auth_module = "gitlab"
```

This allows:

- `@example-commons/foo` -> `gitlab.example.com/commons/foo`

### v1 limits

- root-level `package.json` only
- `package.json.name` must exactly match the rewritten public package name
- no build step during package synthesis
- no monorepo subdir packaging
- no npm publish support
- no interception of raw `git+https://...` dependencies

## Verification

This branch was exercised with:

- targeted unit and e2e coverage for:
  - mixed-mode runtime
  - npm metadata caching
  - ETag revalidation
  - protected scopes
  - rewrite rule config validation
  - GitLab-backed metadata synthesis
  - GitLab-backed tarball synthesis
  - derived repo-path authorization
  - disk and S3-backed npm caching
  - paginated GitLab tag discovery
- real-client `pnpm add` smoke against deterministic fixtures
- full `go test ./...`
- full `go test -race ./...`

## Operator notes

- npm cache now works with either:
  - `cache.type = "disk"` + `cache.disk.path`
  - `cache.type = "s3"` + `cache.s3` configuration
- rewrite rules take precedence over upstream npm proxying
- rewrite-backed installs require an auth module in v1

## Commits of note

- `feat(runtime): add mixed-mode go and npm listeners`
- `feat(auth): add protocol-aware npm scope protection`
- `feat(npm): add rewrite rule config primitives`
- `feat(npm): synthesize rewrite metadata from gitlab`
- `feat(npm): synthesize rewrite tarballs from gitlab`
- `fix(auth): bind rewrite npm auth to derived repo paths`
- `feat(npm): support s3-backed cache storage`
- `fix(npm): harden final review findings`
